### PR TITLE
Adding theme dirs into Assetic DirectoryResources

### DIFF
--- a/DependencyInjection/Compiler/ThemeCompilerPass.php
+++ b/DependencyInjection/Compiler/ThemeCompilerPass.php
@@ -14,5 +14,58 @@ class ThemeCompilerPass implements CompilerPassInterface
         $container->getDefinition('templating.locator')
             ->replaceArgument(0, new Reference('liip_theme.file_locator'))
         ;
+        
+        // Fix directories, where Assetic looks for templates
+        // Without this Assetic won't create routes for assets mentioned in theme templates
+        if ($container->has('assetic.asset_manager')) {
+            $themes = $container->getParameter('liip_theme.themes');
+            
+            // Fix bundle folders
+            foreach ($container->getParameter('kernel.bundles') as $bundleName => $bundleClass) {
+                foreach (array('twig', 'php') as $engine) {
+                    if (!$container->hasDefinition('assetic.'.$engine.'_directory_resource.'.$bundleName)) {
+                        continue;
+                    }
+                    $newResources = array();
+                    foreach ($themes as $theme) {
+                        $newResources[] = new \Symfony\Bundle\AsseticBundle\DependencyInjection\DirectoryResourceDefinition(
+                            $bundleName, 
+                            $engine, 
+                            array($container->getParameter('kernel.root_dir').'/Resources/themes/'.$theme.'/'.$bundleName.'/views')
+                        );
+                    }
+                    
+                    // Bundle DirectoryResourceDefinition are always CoalescingDirectoryResource
+                    // so we can safely merge our theme folders on top of existing folders
+                    $container->getDefinition('assetic.'.$engine.'_directory_resource.'.$bundleName)
+                        ->replaceArgument(
+                            0,
+                            array_merge(
+                                $newResources, 
+                                $container->getDefinition('assetic.'.$engine.'_directory_resource.'.$bundleName)
+                                    ->getArgument(0)
+                            ) 
+                        );
+                }
+            }
+            
+            // Fix base Resources/views folder
+            $folders = array();
+            foreach ($themes as $theme) {
+                $folders[] = $container->getParameter('kernel.root_dir').'/Resources/themes/'.$theme.'/views';
+            }
+            $folders[] = $container->getParameter('kernel.root_dir').'/Resources/views';
+            
+            // Base (Kernel's) DirectoryResourceDefinition is normally 
+            // a single directory, so we need to rebuild it from scratch (can't just merege params)
+            // DirectoryResourceDefinition automatically creates CoalescingDirectoryResource
+            // when there are more than 1 directory
+            foreach (array('twig', 'php') as $engine) {
+                $container->setDefinition(
+                    'assetic.'.$engine.'_directory_resource.kernel',
+                    new \Symfony\Bundle\AsseticBundle\DependencyInjection\DirectoryResourceDefinition('', $engine, $folders)
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
Assetic scans only standard directories for templates, containing assets. These changes will add theme directories (of all bundles and base Resources/themes/a_theme/views) into the list Assetic scans (through CoalescingDirectoryResource)
