### PR TITLE
make cookie complete configurable

### DIFF
--- a/Controller/ThemeController.php
+++ b/Controller/ThemeController.php
@@ -34,24 +34,24 @@ class ThemeController
     protected $themes;
 
     /**
-     * Name of the cookie to store active theme
+     * Options of the cookie to store active theme
      * 
-     * @var string
+     * @var array
      */
-    protected $cookieName;
+    protected $cookieOptions;
 
     /**
      * Theme controller construct
      * 
-     * @param ActiveTheme $activeTheme active theme instance
-     * @param array       $themes      Available themes
-     * @param string      $cookieName  cookie name to store active theme
+     * @param ActiveTheme $activeTheme   active theme instance
+     * @param array       $themes        Available themes
+     * @param array       $cookieOptions The options of the cookie we look for the theme to set
      */
-    public function __construct(ActiveTheme $activeTheme, array $themes, $cookieName)
+    public function __construct(ActiveTheme $activeTheme, array $themes, array $cookieOptions)
     {
-        $this->activeTheme = $activeTheme;
-        $this->themes      = $themes;
-        $this->cookieName  = $cookieName;
+        $this->activeTheme    = $activeTheme;
+        $this->themes         = $themes;
+        $this->cookieOptions  = $cookieOptions;
     }
 
     /**
@@ -74,7 +74,7 @@ class ThemeController
         $this->activeTheme->setName($theme);
 
         $url = $request->headers->get('Referer');
-        $cookie = new Cookie($this->cookieName, $theme, time()+60*60*24*365, '/', null, false, false);
+        $cookie = new Cookie($this->cookieOptions['name'], $theme, time() + $this->cookieOptions['lifetime'], $this->cookieOptions['path'], $this->cookieOptions['domain'], (bool) $this->cookieOptions['secure'], (bool) $this->cookieOptions['httponly']);
 
         $response = new RedirectResponse($url);
         $response->headers->setCookie($cookie);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,14 +40,24 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('themes')
                     ->useAttributeAsKey('theme')
-                    ->prototype('scalar')
+                    ->prototype('scalar')->end()
                 ->end()
+                ->scalarNode('active_theme')->defaultNull()->end()
+                ->arrayNode('cookie')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('name')->end()
+                        ->scalarNode('lifetime')->defaultValue(31536000)->end()
+                        ->scalarNode('path')->defaultValue('/')->end()
+                        ->scalarNode('domain')->defaultNull()->end()
+                        ->booleanNode('secure')->defaultFalse()->end()
+                        ->booleanNode('httponly')->defaultFalse()->end()
+                    ->end()
+                ->end()
+                ->scalarNode('autodetect_theme')->defaultFalse()->end()
+                ->booleanNode('cache_warming')->defaultTrue()->end()
             ->end()
-            ->scalarNode('active_theme')->defaultNull()->end()
-            ->scalarNode('theme_cookie')->defaultNull()->end()
-            ->scalarNode('autodetect_theme')->defaultFalse()->end()
-            ->booleanNode('cache_warming')->defaultTrue()->end()
-        ->end();
+        ;
 
         return $treeBuilder;
     }

--- a/DependencyInjection/LiipThemeExtension.php
+++ b/DependencyInjection/LiipThemeExtension.php
@@ -39,8 +39,15 @@ class LiipThemeExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
-        if (!empty($config['theme_cookie'])) {
-            $container->setParameter($this->getAlias().'.theme_cookie', $config['theme_cookie']);
+        if (!empty($config['cookie'])) {
+            $options = array();
+            foreach (array('name', 'lifetime', 'path', 'domain', 'secure', 'httponly') as $key) {
+                if (isset($config['cookie'][$key])) {
+                    $options[$key] = $config['cookie'][$key];
+                }
+            }
+            $container->setParameter($this->getAlias().'.cookie', $options);
+
             $loader->load('theme_request_listener.xml');
 
             if (!empty($config['autodetect_theme'])) {

--- a/EventListener/ThemeRequestListener.php
+++ b/EventListener/ThemeRequestListener.php
@@ -33,9 +33,9 @@ class ThemeRequestListener
     protected $activeTheme;
 
     /**
-     * @var string
+     * @var array
      */
-    protected $cookieName;
+    protected $cookieOptions;
 
     /**
      * @var DeviceDetectionInterface
@@ -49,13 +49,13 @@ class ThemeRequestListener
 
     /**
      * @param ActiveTheme              $activeTheme
-     * @param string                   $cookieName The name of the cookie we look for the theme to set
-     * @param DeviceDetectionInterface $autoDetect If to auto detect the theme based on the user agent
+     * @param array                    $cookieOptions The options of the cookie we look for the theme to set
+     * @param DeviceDetectionInterface $autoDetect    If to auto detect the theme based on the user agent
      */
-    public function __construct($activeTheme, $cookieName, $autoDetect = null)
+    public function __construct($activeTheme, $cookieOptions, $autoDetect = null)
     {
         $this->activeTheme = $activeTheme;
-        $this->cookieName = $cookieName;
+        $this->cookieOptions = $cookieOptions;
         $this->autoDetect = $autoDetect;
     }
 
@@ -65,7 +65,7 @@ class ThemeRequestListener
      public function onKernelRequest(GetResponseEvent $event)
      {
          if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
-             $activeCookie = $event->getRequest()->cookies->get($this->cookieName);
+             $activeCookie = $event->getRequest()->cookies->get($this->cookieOptions['name']);
 
              if (!$activeCookie && $this->autoDetect instanceof DeviceDetectionInterface) {
                  $userAgent = $event->getRequest()->server->get('HTTP_USER_AGENT');
@@ -86,7 +86,7 @@ class ThemeRequestListener
      {
          if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
              if ($this->newTheme) {
-                 $cookie = new Cookie($this->cookieName, $this->newTheme, time()+60*60*24*365, '/', null, false, false);
+                 $cookie = new Cookie($this->cookieOptions['name'], $this->newTheme, time() + $this->cookieOptions['lifetime'], $this->cookieOptions['path'], $this->cookieOptions['domain'], (bool) $this->cookieOptions['secure'], (bool) $this->cookieOptions['httponly']);
                  $event->getResponse()->headers->setCookie($cookie);
              }
          }

--- a/README.md
+++ b/README.md
@@ -106,25 +106,36 @@ Or if you prefer XML:
 You will have to set your possible themes and the currently active theme. It
 is required that the active theme is part of the themes list.
 
-    # app/config/config.yml
-        liip_theme:
-            themes: ['web', 'tablet', 'mobile']
-            active_theme: 'web'
+``` yaml
+# app/config/config.yml
+liip_theme:
+    themes: ['web', 'tablet', 'mobile']
+    active_theme: 'web'
+```
 
 ### Optional
 
 If you want to select the active theme based on a cookie you can add
 
-    # app/config/config.yml
-        liip_theme:
-            theme_cookie: cookieName
+``` yaml
+# app/config/config.yml
+liip_theme:
+    cookie:
+        name: NameOfTheCookie
+        lifetime: 31536000 # 1 year in seconds
+        path: /
+        domain: ~
+        secure: false
+        httponly: false
+```
 
 It is also possible to automate setting the theme cookie based on the user agent:
 
-    # app/config/config.yml
-        liip_theme:
-            theme_cookie: cookieName
-            autodetect_theme: true
+``` yaml
+# app/config/config.yml
+liip_theme:
+    autodetect_theme: true
+```
 
 Optionally ``autodetect_theme`` can also be set to a DIC service id that implements
 the ``Liip\ThemeBundle\Helper\DeviceDetectionInterface`` interface.
@@ -147,9 +158,11 @@ If you are early in the request cycle and no template has been rendered you
 can still change the theme without problems. For this the theme service
 exists at:
 
-    $activeTheme = $container->get('liip_theme.active_theme');
-    echo $activeTheme->getName();
-    $activeTheme->setName("mobile");
+``` php
+$activeTheme = $container->get('liip_theme.active_theme');
+echo $activeTheme->getName();
+$activeTheme->setName("mobile");
+```
 
 ## Contribution
 
@@ -164,4 +177,6 @@ First initial vendors:
 
 This will give you proper results:
 
-    phpunit --coverage-text
+``` bash
+phpunit --coverage-html reports
+```

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -12,7 +12,7 @@
         <service id="liip_theme.theme_controller" class="%liip_theme.theme_controller.class%">
             <argument type="service" id="liip_theme.active_theme" />
             <argument>%liip_theme.themes%</argument>
-            <argument>%liip_theme.theme_cookie%</argument>
+            <argument>%liip_theme.cookie%</argument>
         </service>
     </services>
 </container>

--- a/Resources/config/theme_request_listener.xml
+++ b/Resources/config/theme_request_listener.xml
@@ -12,7 +12,7 @@
     <services>
         <service id="liip_theme.theme_request_listener" class="%liip_theme.theme_request_listener.class%">
             <argument type="service" id="liip_theme.active_theme" />
-            <argument>%liip_theme.theme_cookie%</argument>
+            <argument>%liip_theme.cookie%</argument>
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
         </service>

--- a/Tests/DependencyInjection/LiipThemeExtensionTest.php
+++ b/Tests/DependencyInjection/LiipThemeExtensionTest.php
@@ -33,13 +33,13 @@ class LiipThemeExtensionTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $loader = new LiipThemeExtension();
         $config = $this->getConfig();
-        $config['theme_cookie'] = 'themeBundleCookie';
+        $config['cookie'] = array('name' => 'themeBundleCookie');
         $config['autodetect_theme'] = false;
         $loader->load(array($config), $container);
 
         $this->assertEquals(array('web', 'tablet', 'mobile'), $container->getParameter('liip_theme.themes'));
         $this->assertEquals('tablet', $container->getParameter('liip_theme.active_theme'));
-        $this->assertEquals('themeBundleCookie', $container->getParameter('liip_theme.theme_cookie'));
+        $this->assertEquals(array('name' => 'themeBundleCookie', 'lifetime' => 31536000, 'path' => '/', 'secure' => false, 'httponly' => false), $container->getParameter('liip_theme.cookie'));
 
         $listener = $container->get('liip_theme.theme_request_listener');
         $this->assertInstanceOf('Liip\ThemeBundle\EventListener\ThemeRequestListener', $listener);


### PR DESCRIPTION
Problem: At the moment it is not possible to change the cookie setting like domain, lifetime, path ...

The PR change the config format so it is a BC break. Now It is the same format as remember_me and the framework security session cookie config.
# app/config/config.yml

Actual:

```
liip_theme:
            theme_cookie: cookieName
```

After:

```
liip_theme:
    cookie:
        name: cookieName
        domain: example.com
        lifetime: 3600
        path: /
```
