### PR TITLE
README.md precisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ with theme name ``phone`` is located at:
 3. Bundle theme directory: `src/BundleName/Resources/themes/phone/template.html.twig`
 4. Bundle view directory: `src/BundleName/Resources/views/template.html.twig`
 
+For exemple, if you want to integrate some TwigBundle custom error pages regarding your theme 
+architecture, you will have to use this directory structure : 
+`app/Resources/themes/phone/TwigBundle/Exception/error404.html.twig`
+
 The following order is applied when checking for application-wide base templates, for example `::template.html.twig`
 with theme name ``phone`` is located at:
 


### PR DESCRIPTION
Added some text into the README.md file in order to help people understand how to deal with themes directory structure with a Bundle. I gave an example of how to integrate TwigBundle custom error pages.
