### PR TITLE
Changed the visibility of helper methods in the FileLocator

### DIFF
--- a/Locator/FileLocator.php
+++ b/Locator/FileLocator.php
@@ -146,7 +146,7 @@ class FileLocator extends BaseFileLocator
      * @param bool $first
      * @return string
      */
-    public function locateBundleResource($name, $dir = null, $first = true)
+    protected function locateBundleResource($name, $dir = null, $first = true)
     {
         if (false !== strpos($name, '..')) {
             throw new \RuntimeException(sprintf('File name "%s" contains invalid characters (..).', $name));
@@ -224,7 +224,7 @@ class FileLocator extends BaseFileLocator
      * @param bool $first
      * @return string|array
      */
-    public function locateAppResource($name, $dir = null, $first = true)
+    protected function locateAppResource($name, $dir = null, $first = true)
     {
         if (false !== strpos($name, '..')) {
             throw new \RuntimeException(sprintf('File name "%s" contains invalid characters (..).', $name));


### PR DESCRIPTION
These 2 methods are only used by locate() in the same file, so they don't need to be public.
Thus, making a direct call to one of them would break the resolution logic after a theme change as they always use the cached theme name. The update of the theme based on the ActiveTheme is done by `locate` only.
