### PR TITLE
Prevent overriding default path patterns with user configs

### DIFF
--- a/Locator/FileLocator.php
+++ b/Locator/FileLocator.php
@@ -45,13 +45,13 @@ class FileLocator extends BaseFileLocator
     /**
      * Constructor.
      *
-     * @param KernelInterface $kernel A KernelInterface instance
-     * @param string $path The path the global resource directory
-     *
-     * @throws \InvalidArgumentException if the active theme is not in the themes list
+     * @param KernelInterface $kernel       A KernelInterface instance
+     * @param ActiveTheme     $activeTheme  A ActiveTheme instance
+     * @param string|null     $path         Path
+     * @param array           $paths        Base paths
+     * @param array           $pathPatterns Fallback paths pattern
      */
-    public function __construct(KernelInterface $kernel, ActiveTheme $activeTheme, $path = null, array $paths = array(),
-        array $pathPatterns = array())
+    public function __construct(KernelInterface $kernel, ActiveTheme $activeTheme, $path = null, array $paths = array(), array $pathPatterns = array())
     {
         $this->kernel = $kernel;
         $this->activeTheme = $activeTheme;
@@ -72,7 +72,7 @@ class FileLocator extends BaseFileLocator
             ),
         );
 
-        $this->pathPatterns = array_replace($defaultPathPatterns, array_filter($pathPatterns));
+        $this->pathPatterns = array_merge_recursive($defaultPathPatterns, array_filter($pathPatterns));
 
         $this->setCurrentTheme($this->activeTheme->getName());
     }

--- a/Tests/Locator/FileLocatorTest.php
+++ b/Tests/Locator/FileLocatorTest.php
@@ -69,6 +69,73 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Liip\ThemeBundle\Locator\FileLocator::__construct
+     */
+    public function testConstructorFallbackPathMerge()
+    {
+        $kernel =  $this->getKernelMock();
+        $activeTheme = new ActiveTheme('bar', array('foo', 'bar', 'foobar'));
+        $property = new \ReflectionProperty('Liip\ThemeBundle\Locator\FileLocator', 'pathPatterns');
+        $property->setAccessible(true);
+
+        $fileLocator = new FileLocator($kernel, $activeTheme, $this->getFixturePath() . '/rootdir/Resources');
+        $this->assertEquals(
+            array(
+                'app_resource' => array(
+                    '%app_path%/themes/%current_theme%/%template%',
+                    '%app_path%/views/%template%',
+                ),
+                'bundle_resource' => array(
+                    '%bundle_path%/Resources/themes/%current_theme%/%template%',
+                ),
+                'bundle_resource_dir' => array(
+                    '%dir%/themes/%current_theme%/%bundle_name%/%template%',
+                    '%dir%/%bundle_name%/%override_path%',
+                ),
+            ),
+            $property->getValue($fileLocator)
+        );
+
+        $fileLocator = new FileLocator(
+            $kernel,
+            $activeTheme,
+            $this->getFixturePath() . '/rootdir/Resources',
+            array(),
+            array(
+                'app_resource' => array(
+                    '%app_path%/themes/fallback/%template%'
+                ),
+                'bundle_resource' => array(
+                    '%bundle_path%/Resources/themes/fallback/%template%'
+                ),
+                'bundle_resource_dir' => array(
+                    '%dir%/themes/fallback/%bundle_name%/%template%'
+                )
+            )
+        );
+
+        $this->assertEquals(
+            array(
+                'app_resource' => array(
+                    '%app_path%/themes/%current_theme%/%template%',
+                    '%app_path%/views/%template%',
+                    '%app_path%/themes/fallback/%template%'
+                ),
+                'bundle_resource' => array(
+                    '%bundle_path%/Resources/themes/%current_theme%/%template%',
+                    '%bundle_path%/Resources/themes/fallback/%template%'
+                ),
+                'bundle_resource_dir' => array(
+                    '%dir%/themes/%current_theme%/%bundle_name%/%template%',
+                    '%dir%/%bundle_name%/%override_path%',
+                    '%dir%/themes/fallback/%bundle_name%/%template%'
+                ),
+            ),
+            $property->getValue($fileLocator)
+        );
+    }
+
+    /**
      * @covers Liip\ThemeBundle\Locator\FileLocator::locate
      * @covers Liip\ThemeBundle\Locator\FileLocator::locateBundleResource
      */
@@ -100,7 +167,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
         $fileLocator = new FileLocator($kernel, $activeTheme, $this->getFixturePath() . '/rootdir/Resources', array(), $pathPatterns);
 
         $file = $fileLocator->locate('@ThemeBundle/Resources/views/template', $this->getFixturePath(), true);
-        $this->assertEquals($this->getFixturePath().'/Resources/themes2/foo/template', $file);
+        $this->assertEquals($this->getFixturePath().'/Resources/themes/foo/template', $file);
     }
 
     /**


### PR DESCRIPTION
The goal of this PR is to prevent overriding default paths patterns with user configs.

config.yml

```
liip_theme:
    themes: ['web', 'tablet', 'phone']
    active_theme: 'tablet'
    path_patterns:
        bundle_resource:
            - %%bundle_path%%/Resources/themes/web/%%template%%
        bundle_resource_dir:
            - %%dir%%/themes/web/%%bundle_name%%/%%template%%
```

Dir structure:

```

├── Acme
│   ├── DemoBundle
│   │   ├── Resources
│   │   │   ├── themes
│   │   │   │   ├── tablet
│   │   │   │   │   └── index.html.twig
│   │   │   │   ├── web
│   │   │   │   │   └── index.html.twig
│   │   │   │   │   └── inner.html.twig
```

tablet/index.html.twig

```
Tablet
{% include 'AcmeDemoBundle::inner.html.twig' %}
```

web/index.html.twig

```
Desktop
{% include 'AcmeDemoBundle::inner.html.twig' %}
```

web/inner.html.twig

```
inner
```

**Before:** Default paths would be overridden and all templates will load from `web` theme, but should from `tablet`

Result
- **Expected**: Tablet inner
- **Getting**: Desktop inner

**After:** User paths will be appended to array
