### PR TITLE
Not working in devices after new update

### DIFF
--- a/EventListener/ThemeRequestListener.php
+++ b/EventListener/ThemeRequestListener.php
@@ -73,7 +73,6 @@ class ThemeRequestListener
 
             if (!$cookieValue && $this->autoDetect instanceof DeviceDetectionInterface) {
                 $cookieValue = $this->getThemeType($event->getRequest());
-		$this->activeTheme->setName($cookieValue);
             }
 
             if ($cookieValue && $cookieValue !== $this->activeTheme->getName()

--- a/EventListener/ThemeRequestListener.php
+++ b/EventListener/ThemeRequestListener.php
@@ -73,6 +73,7 @@ class ThemeRequestListener
 
             if (!$cookieValue && $this->autoDetect instanceof DeviceDetectionInterface) {
                 $cookieValue = $this->getThemeType($event->getRequest());
+		$this->activeTheme->setName($cookieValue);
             }
 
             if ($cookieValue && $cookieValue !== $this->activeTheme->getName()

--- a/Helper/DeviceDetection.php
+++ b/Helper/DeviceDetection.php
@@ -37,7 +37,6 @@ class DeviceDetection implements DeviceDetectionInterface
             "osx" => "Mac OS X",
             "linux" => "Linux",
             "windows" => "Windows",
-            "generic" => "",
         )
     );
 


### PR DESCRIPTION
So I can't really understand what did you change, but currently with dev-master version I can't use anymore this bundle.

by deleting the generic as empty string everything works again.

btw: I used this config
iip_theme:
    autodetect_theme: true
    active_theme: 'tablet'
    themes: ['desktop', 'tablet', 'phone']
    path_patterns:
        app_resource:
            - %%app_path%%/Resources/themes/%%current_theme%%/%%override_path%%
        bundle_resource:
            - %%app_path%%/Resources/%%bundle_name%%/themes/%%current_theme%%/%%override_path%%
            - %%bundle_path%%/Resources/themes/%%current_theme%%/%%override_path%%