### PR TITLE
Removing setCurrentTheme on FileLoctor constructor

### DIFF
--- a/Locator/FileLocator.php
+++ b/Locator/FileLocator.php
@@ -81,8 +81,9 @@ class FileLocator extends BaseFileLocator
         );
 
         $this->pathPatterns = array_merge_recursive(array_filter($pathPatterns), $defaultPathPatterns);
+        
+        $this->lastTheme = $this->activeTheme->getName();
 
-        $this->setCurrentTheme($this->activeTheme->getName(), $this->activeTheme->getDeviceType());
     }
 
     /**


### PR DESCRIPTION
This statement avoids device autodetection to work. Changed the line to lastTheme setting that way it doesn't break the lastTheme tests.