### PR TITLE
Fixed crash in FileLocator

### DIFF
--- a/Locator/FileLocator.php
+++ b/Locator/FileLocator.php
@@ -81,9 +81,10 @@ class FileLocator extends BaseFileLocator
         );
 
         $this->pathPatterns = array_merge_recursive(array_filter($pathPatterns), $defaultPathPatterns);
-        
+
         $this->lastTheme = $this->activeTheme->getName();
 
+        parent::__construct(array());
     }
 
     /**


### PR DESCRIPTION
Calling the original constructor will initiate the `paths` property correctly.

Fixed https://github.com/liip/LiipThemeBundle/issues/114