### PR TITLE
Add custom twig loader to workaround cache issue

### DIFF
--- a/DependencyInjection/Compiler/ThemeCompilerPass.php
+++ b/DependencyInjection/Compiler/ThemeCompilerPass.php
@@ -23,6 +23,8 @@ class ThemeCompilerPass implements CompilerPassInterface
 
         $container->setAlias('templating.cache_warmer.template_paths', 'liip_theme.templating.cache_warmer.template_paths');
 
+        $container->setAlias('twig.loader', 'liip_theme.twig.loader.filesystem');
+
         if (!$container->getParameter('liip_theme.cache_warming')) {
             $container->getDefinition('liip_theme.templating.cache_warmer.template_paths')
                 ->replaceArgument(2, null);

--- a/Loader/FilesystemLoader.php
+++ b/Loader/FilesystemLoader.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Liip\ThemeBundle\Loader;
+
+
+use Liip\ThemeBundle\ActiveTheme;
+use Symfony\Bundle\TwigBundle\Loader\FilesystemLoader as BaseFilesystemLoader;
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Templating\TemplateNameParserInterface;
+
+class FilesystemLoader extends BaseFilesystemLoader
+{
+    public function __construct(FileLocatorInterface $locator, TemplateNameParserInterface $parser, ActiveTheme $activeTheme)
+    {
+        $this->activeTheme = $activeTheme;
+        parent::__construct($locator, $parser);
+    }
+
+    protected function findTemplate($template)
+    {
+        $logicalName = (string)$template;
+        $cacheKey = $logicalName;
+        if($theme = $this->activeTheme->getName()) {
+            $cacheKey = $cacheKey . '|' . $theme;
+        }
+
+        if(isset($this->cache[$cacheKey])) {
+            return $this->cache[$cacheKey];
+        }
+
+        $file = parent::findTemplate($template);
+
+        unset($this->cache[$logicalName]);
+        $this->cache[$cacheKey] = $file;
+
+        return $file;
+    }
+
+
+
+
+}

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -9,6 +9,7 @@
         <parameter key="liip_theme.active_theme.class">Liip\ThemeBundle\ActiveTheme</parameter>
         <parameter key="liip_theme.cache_warmer.class">Liip\ThemeBundle\CacheWarmer\TemplatePathsCacheWarmer</parameter>
         <parameter key="liip_theme.theme_auto_detect.class">Liip\ThemeBundle\Helper\DeviceDetection</parameter>
+        <parameter key="liip_theme.twig.loader.filesystem.class">Liip\ThemeBundle\Loader\FilesystemLoader</parameter>
     </parameters>
 
     <services>
@@ -23,6 +24,13 @@
             <argument type="service" id="liip_theme.file_locator" />
             <argument>%kernel.cache_dir%</argument>
             <argument type="service" id="liip_theme.active_theme" />
+        </service>
+
+        <service id="liip_theme.twig.loader.filesystem" class="%liip_theme.twig.loader.filesystem.class%" public="false">
+            <argument type="service" id="templating.locator" />
+            <argument type="service" id="templating.name_parser" />
+            <argument type="service" id="liip_theme.active_theme" />
+            <tag name="twig.loader"/>
         </service>
 
         <service id="liip_theme.file_locator" class="%liip_theme.file_locator.class%" public="false">


### PR DESCRIPTION
Proof of concept solution for liip/LiipThemeBundle#79.

Apologies if I have missed something, but this seems as though it can be solved relatively simply by using a custom Twig filesystem loader, as stof suggested. This solution does not solve the 'referencing a non-themed template from a themed template' issue.

Suggestions are welcome.