### PR TITLE
Deduplicate Twig formulae

### DIFF
--- a/Assetic/TwigFormulaLoader.php
+++ b/Assetic/TwigFormulaLoader.php
@@ -60,7 +60,7 @@ class TwigFormulaLoader extends BaseTwigFormulaLoader
                 $this->twig->tokenize($resource->getContent());
 
                 // delegate the formula loading to the parent
-                $formulae = array_merge($formulae, parent::load($resource));
+                $formulae += parent::load($resource);
                 $successTemplates[(string) $resource] = true;
             } catch (\Exception $e) {
                 $failureTemplates[(string) $resource] = $e->getMessage();


### PR DESCRIPTION
Prevent array keys from being renumbered when the formulae arrays are
merged so that we keep the formulae array from containing duplicate
values.