### PR TITLE
Updated to avoid calls deprecated since Symfony2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - env: SYMFONY_VERSION=dev-master
   include:
     - php: 5.5
-      env: SYMFONY_VERSION=2.2.*
+      env: SYMFONY_VERSION=2.3.*
     - php: 5.5
       env: SYMFONY_VERSION=2.4.*
     - php: 5.5
@@ -23,7 +23,9 @@ matrix:
     - php: 5.5
       env: SYMFONY_VERSION=2.6.*
     - php: 5.5
-      env: SYMFONY_VERSION='2.7.*@dev'
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.5
+      env: SYMFONY_VERSION='2.8.*@dev'
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ matrix:
     - env: SYMFONY_VERSION=dev-master
   include:
     - php: 5.5
-      env: SYMFONY_VERSION=2.0.*
-    - php: 5.5
-      env: SYMFONY_VERSION=2.1.*
-    - php: 5.5
       env: SYMFONY_VERSION=2.2.*
     - php: 5.5
       env: SYMFONY_VERSION=2.4.*

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -4,9 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="liip_theme_switch" pattern="/{theme}">
+    <route id="liip_theme_switch" path="/{theme}" methods="GET">
         <default key="_controller">liip_theme.theme_controller:switchAction</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
 </routes>

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.2",
+        "symfony/framework-bundle": "~2.3",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.0",
+        "symfony/framework-bundle": "~2.2",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adresses those two deprecation messages:

- DEPRECATED - The "pattern" option in file "/vagrant/vendor/liip/theme-bundle/Liip/ThemeBundle/Resources/config/routing.xml" is deprecated since version 2.2 and will be removed in 3.0. Use the "path" option in the route definition instead.
- DEPRECATED - The "_method" requirement is deprecated since version 2.2 and will be removed in 3.0. Use the setMethods() method instead or the "methods" option in the route definition.