### PR TITLE
Assets improved

### DIFF
--- a/ActiveTheme.php
+++ b/ActiveTheme.php
@@ -12,6 +12,7 @@
 namespace Liip\ThemeBundle;
 
 use Liip\ThemeBundle\Helper\DeviceDetectionInterface;
+use Liip\ThemeBundle\Locator\ThemeLocator;
 
 /**
  * Contains the currently active theme and allows to change it.
@@ -42,8 +43,10 @@ class ActiveTheme
      * @param array                           $themes
      * @param Helper\DeviceDetectionInterface $deviceDetection
      */
-    public function __construct($name, array $themes = array(), DeviceDetectionInterface $deviceDetection = null)
+    public function __construct($name, array $themes = array(), DeviceDetectionInterface $deviceDetection = null, ThemeLocator $themeLocator)
     {
+        $themes = $themeLocator->discoverThemes();
+
         $this->setThemes($themes);
 
         if ($name) {

--- a/ActiveTheme.php
+++ b/ActiveTheme.php
@@ -45,8 +45,9 @@ class ActiveTheme
      */
     public function __construct($name, array $themes = array(), DeviceDetectionInterface $deviceDetection = null, ThemeLocator $themeLocator)
     {
-        $themes = $themeLocator->discoverThemes();
-
+        if (empty($themes)) {
+            $themes = $themeLocator->discoverThemes();
+        }
         $this->setThemes($themes);
 
         if ($name) {

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -23,7 +23,7 @@ class ThemesInstallCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('themes:install')
+            ->setName('assets:themes-install')
             ->setDefinition(array(
                 new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', 'web'),
             ))

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -47,7 +47,7 @@ class ThemesInstallCommand extends ContainerAwareCommand
 
         // Retrieve the active theme.
         $activeTheme = $this->getContainer()->get('liip_theme.active_theme');
-        $availableThemes = $this->getContainer()->getParameter("available_themes");
+        $availableThemes = $this->getContainer()->getParameter("liip_theme.themes");
         $filesystem = $this->getContainer()->get('filesystem');
 
         $themesAssetsDir = $targetArg . DIRECTORY_SEPARATOR . "themes";
@@ -71,8 +71,7 @@ class ThemesInstallCommand extends ContainerAwareCommand
             // Search in bundles first.
             $bundle = $themeLocator->locateThemeInBundles($theme);
             if(!empty($bundle)) {
-                $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment>', $theme, $bundle["bundle"]->getName()));
-
+                // Prepare the directory for this bundle.
                 $themesAssetsBundleDir = $themesAssetsDir . DIRECTORY_SEPARATOR . strtolower($bundle["bundle"]->getName());
                 if(!is_dir($themesAssetsBundleDir)) {
                     $filesystem->mkdir($themesAssetsBundleDir, 0777);
@@ -81,6 +80,8 @@ class ThemesInstallCommand extends ContainerAwareCommand
                 // Found theme in bundle.
                 $originDir = $bundle["path"];
                 $targetDir = $themesAssetsBundleDir . DIRECTORY_SEPARATOR . $theme;
+
+                $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $bundle["bundle"]->getName(), $targetDir));
             } else {
                 // Search in app/
                 $path = $themeLocator->locateThemeInApp($theme);
@@ -88,6 +89,8 @@ class ThemesInstallCommand extends ContainerAwareCommand
                     $originDir = $path;
                     $targetDir = $appThemesDir . DIRECTORY_SEPARATOR . $theme;
                 }
+
+                $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $originDir, $targetDir));
             }
 
             if($originDir && $targetDir) {
@@ -100,17 +103,6 @@ class ThemesInstallCommand extends ContainerAwareCommand
                 }
             }
         }
-    }
-
-    /**
-     * Makes a symlink
-     * @param  [type] $originDir [description]
-     * @param  [type] $targetDir [description]
-     * @return [type]            [description]
-     */
-    public function symlink($originDir, $targetDir)
-    {
-
     }
 
     /**

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -49,11 +49,8 @@ class ThemesInstallCommand extends ContainerAwareCommand
         $activeTheme = $this->getContainer()->get('liip_theme.active_theme');
         $availableThemes = $activeTheme->getThemes();
 
-        $filesystem = $this->getContainer()->get('filesystem');
-
         $themesAssetsDir = $targetArg . DIRECTORY_SEPARATOR . "themes";
-        $filesystem->remove($themesAssetsDir);
-        $filesystem->mkdir($themesAssetsDir, 0777);
+
 
         // Do we hard copy or symlink ?
         $symlink = $input->getOption('symlink');
@@ -66,56 +63,8 @@ class ThemesInstallCommand extends ContainerAwareCommand
         foreach($availableThemes as $theme) {
             $output->writeln(sprintf('Installing assets for <comment>%s</comment>', $theme));
 
-            // Find theme path.
-            $themeLocator = $this->getContainer()->get("liip_theme.theme_locator");
-
-            // Search in bundles first.
-            $bundle = $themeLocator->locateThemeInBundles($theme);
-            if(!empty($bundle)) {
-                // Prepare the directory for this bundle.
-                $themesAssetsBundleDir = $themesAssetsDir . DIRECTORY_SEPARATOR . strtolower($bundle["bundle"]->getName());
-                if(!is_dir($themesAssetsBundleDir)) {
-                    $filesystem->mkdir($themesAssetsBundleDir, 0777);
-                }
-
-                // Found theme in bundle.
-                $originDir = $bundle["path"];
-                $targetDir = $themesAssetsBundleDir . DIRECTORY_SEPARATOR . $theme;
-
-                $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $bundle["bundle"]->getName(), $targetDir));
-            } else {
-                // Search in app/
-                $path = $themeLocator->locateThemeInApp($theme);
-                if($path) {
-                    $originDir = $path;
-                    $targetDir = $appThemesDir . DIRECTORY_SEPARATOR . $theme;
-                }
-
-                $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $originDir, $targetDir));
-            }
-
-            if($originDir && $targetDir) {
-                if($symlink) {
-                    // Symlink.
-                    $filesystem->symlink($originDir, $targetDir, true);
-                } else {
-                    // Hard copy.
-                    $this->hardCopy($originDir, $targetDir);
-                }
-            }
+            // Install assets for this theme.
+            $this->getContainer()->get('liip_theme.installer')->installAssets($theme, $themesAssetsDir);
         }
-    }
-
-    /**
-     * @param string $originDir
-     * @param string $targetDir
-     */
-    private function hardCopy($originDir, $targetDir)
-    {
-        $filesystem = $this->getContainer()->get('filesystem');
-
-        $filesystem->mkdir($targetDir, 0777);
-        // We use a custom iterator to ignore VCS files
-        $filesystem->mirror($originDir, $targetDir, Finder::create()->ignoreDotFiles(false)->in($originDir));
     }
 }

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Liip/ThemeBundle
+ *
+ * (c) Liip AG
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Liip\ThemeBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -45,26 +45,24 @@ class ThemesInstallCommand extends ContainerAwareCommand
             throw new \InvalidArgumentException(sprintf('The target directory "%s" does not exist.', $input->getArgument('target')));
         }
 
+        // Target themes assets directory.
+        $themesAssetsDir = $targetArg . DIRECTORY_SEPARATOR . "themes";
+
         // Retrieve the active theme.
         $activeTheme = $this->getContainer()->get('liip_theme.active_theme');
         $availableThemes = $activeTheme->getThemes();
 
-        $themesAssetsDir = $targetArg . DIRECTORY_SEPARATOR . "themes";
-
-
-        // Do we hard copy or symlink ?
-        $symlink = $input->getOption('symlink');
-        if($symlink) {
-            $output->writeln('Trying to install theme assets as <comment>symbolic links</comment>.');
-        } else {
-            $output->writeln('Installing theme assets as <comment>hard copies</comment>.');
-        }
+        // if($symlink) {
+        //     $output->writeln('Trying to install theme assets as <comment>symbolic links</comment>.');
+        // } else {
+        //     $output->writeln('Installing theme assets as <comment>hard copies</comment>.');
+        // }
 
         foreach($availableThemes as $theme) {
             $output->writeln(sprintf('Installing assets for <comment>%s</comment>', $theme));
 
             // Install assets for this theme.
-            $this->getContainer()->get('liip_theme.installer')->installAssets($theme, $themesAssetsDir);
+            $this->getContainer()->get('liip_theme.installer')->installAssets($theme, $themesAssetsDir, $input->getOption('symlink'));
         }
     }
 }

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -56,10 +56,14 @@ class ThemesInstallCommand extends ContainerAwareCommand
 
         // Target themes assets directory.
         $themesAssetsDir = $targetArg . DIRECTORY_SEPARATOR . "themes";
+        if(file_exists($themesAssetsDir)) {
+            $this->getContainer()->get('filesystem')->remove($themesAssetsDir);
+        }
 
         // Retrieve the active theme.
         $activeTheme = $this->getContainer()->get('liip_theme.active_theme');
         $availableThemes = $activeTheme->getThemes();
+        $installedThemes = [];
 
         // Logging install mode.
         if($input->getOption('symlink')) {
@@ -69,12 +73,15 @@ class ThemesInstallCommand extends ContainerAwareCommand
         }
 
         // Logging list of discovered themes.
-        $output->writeLn(sprintf("Installing following theme(s) assets: <comment>%s</comment>.", join(', ', $availableThemes)));
+        $output->writeLn(sprintf("Found following theme(s) to install: <comment>%s</comment>.", join(', ', $availableThemes)));
         foreach($availableThemes as $theme) {
             // Install assets for this theme.
-            $this->getContainer()->get('liip_theme.installer')->installAssets($theme, $themesAssetsDir, $input->getOption('symlink'));
+            $installed = $this->getContainer()->get('liip_theme.installer')->installAssets($theme, $themesAssetsDir, $input->getOption('symlink'));
+            if($installed === true) {
+                array_push($installedThemes, $theme);
+            }
         }
 
-        $output->writeLn(sprintf("<info>Successfully installed assets for %d theme(s).</info>", count($availableThemes)));
+        $output->writeLn(sprintf("<info>Successfully installed assets for %d theme(s).</info>", count($installedThemes)));
     }
 }

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -38,6 +38,22 @@ class ThemesInstallCommand extends ContainerAwareCommand
             ))
             ->addOption('symlink', null, InputOption::VALUE_NONE, 'Symlinks the assets instead of copying it')
             ->setDescription('Installs themes assets into the web directory')
+            ->setHelp(<<<EOT
+The <info>%command.name%</info> command installs themes assets into a given
+directory (e.g. the <comment>web</comment> directory).
+
+  <info>php %command.full_name% web</info>
+
+A "themes" directory will be created inside the target directory and the
+"themes/<options=bold>%theme_name%</>/public" directory of each theme will be copied into it.
+
+To create a symlink to each bundle instead of copying its assets, use the
+<info>--symlink</info> option (will fall back to hard copies when symbolic links aren't possible:
+
+  <info>php %command.full_name% web --symlink</info>
+
+EOT
+            )
         ;
     }
 

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -52,17 +52,20 @@ class ThemesInstallCommand extends ContainerAwareCommand
         $activeTheme = $this->getContainer()->get('liip_theme.active_theme');
         $availableThemes = $activeTheme->getThemes();
 
-        // if($symlink) {
-        //     $output->writeln('Trying to install theme assets as <comment>symbolic links</comment>.');
-        // } else {
-        //     $output->writeln('Installing theme assets as <comment>hard copies</comment>.');
-        // }
+        // Logging install mode.
+        if($input->getOption('symlink')) {
+            $output->writeLn(sprintf('Trying to install theme assets as <comment>symbolic links</comment> in <info>%s</info>.', $themesAssetsDir));
+        } else {
+            $output->writeLn(sprintf('Installing theme assets as <comment>hard copies</comment> in <info>%s</info>.', $themesAssetsDir));
+        }
 
+        // Logging list of discovered themes.
+        $output->writeLn(sprintf("Installing following theme(s) assets: <comment>%s</comment>.", join(', ', $availableThemes)));
         foreach($availableThemes as $theme) {
-            $output->writeln(sprintf('Installing assets for <comment>%s</comment>', $theme));
-
             // Install assets for this theme.
             $this->getContainer()->get('liip_theme.installer')->installAssets($theme, $themesAssetsDir, $input->getOption('symlink'));
         }
+
+        $output->writeLn(sprintf("<info>Successfully installed assets for %d theme(s).</info>", count($availableThemes)));
     }
 }

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -47,7 +47,8 @@ class ThemesInstallCommand extends ContainerAwareCommand
 
         // Retrieve the active theme.
         $activeTheme = $this->getContainer()->get('liip_theme.active_theme');
-        $availableThemes = $this->getContainer()->getParameter("liip_theme.themes");
+        $availableThemes = $activeTheme->getThemes();
+
         $filesystem = $this->getContainer()->get('filesystem');
 
         $themesAssetsDir = $targetArg . DIRECTORY_SEPARATOR . "themes";

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Liip\ThemeBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Command that installs themes assets into the web/ folder
+ *
+ * @author adrienrn
+ */
+class ThemesInstallCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('themes:install')
+            ->setDefinition(array(
+                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', 'web'),
+            ))
+            ->addOption('symlink', null, InputOption::VALUE_NONE, 'Symlinks the assets instead of copying it')
+            ->setDescription('Installs themes assets into the web directory')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException When the target directory does not exist or symlink cannot be used
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // Target directory.
+        $targetArg = rtrim($input->getArgument('target'), '/');
+        if (!is_dir($targetArg)) {
+            throw new \InvalidArgumentException(sprintf('The target directory "%s" does not exist.', $input->getArgument('target')));
+        }
+
+        // Retrieve the active theme.
+        $activeTheme = $this->getContainer()->get('liip_theme.active_theme');
+        $availableThemes = $this->getContainer()->getParameter("available_themes");
+        $filesystem = $this->getContainer()->get('filesystem');
+
+        $themesAssetsDir = $targetArg . DIRECTORY_SEPARATOR . "themes";
+        $filesystem->remove($themesAssetsDir);
+        $filesystem->mkdir($themesAssetsDir, 0777);
+
+        // Do we hard copy or symlink ?
+        $symlink = $input->getOption('symlink');
+        if($symlink) {
+            $output->writeln('Trying to install theme assets as <comment>symbolic links</comment>.');
+        } else {
+            $output->writeln('Installing theme assets as <comment>hard copies</comment>.');
+        }
+
+        foreach($availableThemes as $theme) {
+            $output->writeln(sprintf('Installing assets for <comment>%s</comment>', $theme));
+
+            // Find theme path.
+            $themeLocator = $this->getContainer()->get("liip_theme.theme_locator");
+
+            // Search in bundles first.
+            $bundle = $themeLocator->locateThemeInBundles($theme);
+            if(!empty($bundle)) {
+                $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment>', $theme, $bundle["bundle"]->getName()));
+
+                $themesAssetsBundleDir = $themesAssetsDir . DIRECTORY_SEPARATOR . strtolower($bundle["bundle"]->getName());
+                if(!is_dir($themesAssetsBundleDir)) {
+                    $filesystem->mkdir($themesAssetsBundleDir, 0777);
+                }
+
+                // Found theme in bundle.
+                $originDir = $bundle["path"];
+                $targetDir = $themesAssetsBundleDir . DIRECTORY_SEPARATOR . $theme;
+            } else {
+                // Search in app/
+                $path = $themeLocator->locateThemeInApp($theme);
+                if($path) {
+                    $originDir = $path;
+                    $targetDir = $appThemesDir . DIRECTORY_SEPARATOR . $theme;
+                }
+            }
+
+            if($originDir && $targetDir) {
+                if($symlink) {
+                    // Symlink.
+                    $filesystem->symlink($originDir, $targetDir, true);
+                } else {
+                    // Hard copy.
+                    $this->hardCopy($originDir, $targetDir);
+                }
+            }
+        }
+    }
+
+    /**
+     * Makes a symlink
+     * @param  [type] $originDir [description]
+     * @param  [type] $targetDir [description]
+     * @return [type]            [description]
+     */
+    public function symlink($originDir, $targetDir)
+    {
+
+    }
+
+    /**
+     * @param string $originDir
+     * @param string $targetDir
+     */
+    private function hardCopy($originDir, $targetDir)
+    {
+        $filesystem = $this->getContainer()->get('filesystem');
+
+        $filesystem->mkdir($targetDir, 0777);
+        // We use a custom iterator to ignore VCS files
+        $filesystem->mirror($originDir, $targetDir, Finder::create()->ignoreDotFiles(false)->in($originDir));
+    }
+}

--- a/Command/ThemesInstallCommand.php
+++ b/Command/ThemesInstallCommand.php
@@ -56,7 +56,7 @@ class ThemesInstallCommand extends ContainerAwareCommand
 
         // Target themes assets directory.
         $themesAssetsDir = $targetArg . DIRECTORY_SEPARATOR . "themes";
-        if(file_exists($themesAssetsDir)) {
+        if (file_exists($themesAssetsDir)) {
             $this->getContainer()->get('filesystem')->remove($themesAssetsDir);
         }
 
@@ -66,7 +66,7 @@ class ThemesInstallCommand extends ContainerAwareCommand
         $installedThemes = [];
 
         // Logging install mode.
-        if($input->getOption('symlink')) {
+        if ($input->getOption('symlink')) {
             $output->writeLn(sprintf('Trying to install theme assets as <comment>symbolic links</comment> in <info>%s</info>.', $themesAssetsDir));
         } else {
             $output->writeLn(sprintf('Installing theme assets as <comment>hard copies</comment> in <info>%s</info>.', $themesAssetsDir));
@@ -74,10 +74,10 @@ class ThemesInstallCommand extends ContainerAwareCommand
 
         // Logging list of discovered themes.
         $output->writeLn(sprintf("Found following theme(s) to install: <comment>%s</comment>.", join(', ', $availableThemes)));
-        foreach($availableThemes as $theme) {
+        foreach ($availableThemes as $theme) {
             // Install assets for this theme.
             $installed = $this->getContainer()->get('liip_theme.installer')->installAssets($theme, $themesAssetsDir, $input->getOption('symlink'));
-            if($installed === true) {
+            if ($installed === true) {
                 array_push($installedThemes, $theme);
             }
         }

--- a/Installer.php
+++ b/Installer.php
@@ -5,6 +5,7 @@ namespace Liip\ThemeBundle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Liip\ThemeBundle\Locator\ThemeLocator;
+use Psr\Log\LoggerInterface;
 
 class Installer
 {
@@ -20,10 +21,18 @@ class Installer
      */
     protected $filesystem;
 
-    public function __construct(ThemeLocator $themeLocator, Filesystem $filesystem)
+    /**
+     * Logger.
+     *  Useful since Symfony 2.4 to show output when launching from console.
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    public function __construct(ThemeLocator $themeLocator, Filesystem $filesystem, LoggerInterface $logger = null)
     {
         $this->themeLocator = $themeLocator;
         $this->filesystem = $filesystem;
+        $this->logger = $logger;
     }
 
     /**
@@ -55,7 +64,7 @@ class Installer
 
             $targetDir = $themesAssetsBundleDir . DIRECTORY_SEPARATOR . $theme;
 
-            // $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $bundle["bundle"]->getName(), $targetDir));
+            $this->logger->notice(sprintf('Found theme <comment>%s</comment> in bundle <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $pathInfos["bundle"]->getName(), $targetDir));
         } else {
             // Search in app/
             $path = $this->themeLocator->locateThemeInApp($theme);
@@ -64,7 +73,7 @@ class Installer
                 $targetDir = $appThemesDir . DIRECTORY_SEPARATOR . $theme;
             }
 
-            // $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $originDir, $targetDir));
+            $this->logger->notice(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $originDir, $targetDir));
         }
 
         // Only link / mirror the public folder.

--- a/Installer.php
+++ b/Installer.php
@@ -62,24 +62,24 @@ class Installer
      */
     public function installAssets($theme, $basePath = null, $symlink=true)
     {
-        if(is_null($basePath)) {
+        if (is_null($basePath)) {
             $basePath = "web" . DIRECTORY_SEPARATOR . "themes";
         }
 
-        if(file_exists($basePath) && !is_writable($basePath)) {
+        if (file_exists($basePath) && !is_writable($basePath)) {
             throw new \InvalidArgumentException(
                 "'basePath' is not writable"
             );
         }
 
-        if(!file_exists($basePath)) {
+        if (!file_exists($basePath)) {
             // Create base target directory if needed.
             $this->filesystem->mkdir($basePath, 0777);
         }
 
         // Search in bundles first.
         $pathInfos = $this->themeLocator->locateThemeInBundles($theme);
-        if(!empty($pathInfos)) {
+        if (!empty($pathInfos)) {
             // Found theme in bundle.
             $originDir = $pathInfos["path"];
 
@@ -106,13 +106,13 @@ class Installer
         // Only link / mirror the public folder.
         $originDir = realpath($originDir) . DIRECTORY_SEPARATOR . "public";
 
-        if($originDir && $targetDir) {
-            if(!is_dir($originDir)) {
+        if ($originDir && $targetDir) {
+            if (!is_dir($originDir)) {
                 $this->logger->warning(sprintf("No assets to install for theme %s. <comment>Skipping.</comment>", $theme));
                 return false;
             }
 
-            if($symlink) {
+            if ($symlink) {
                 // Symlink.
                 $this->filesystem->symlink($originDir, $targetDir, true);
             } else {

--- a/Installer.php
+++ b/Installer.php
@@ -47,7 +47,7 @@ class Installer
             $originDir = $bundle["path"];
 
             // Prepare the directory for this bundle.
-            $themesAssetsBundleDir = $basePath . DIRECTORY_SEPARATOR . strtolower($bundle["bundle"]->getName());
+            $themesAssetsBundleDir = $this->getBundleThemesAssetsPath($basePath, $bundle["bundle"]->getName());
             if(!is_dir($themesAssetsBundleDir)) {
                 $this->filesystem->mkdir($themesAssetsBundleDir, 0777);
             }
@@ -81,6 +81,19 @@ class Installer
     }
 
     /**
+     * Get the path for assets of themes from bundles.
+     * @param  string $basePath
+     * @param  string $bundleName
+     * @return string
+     */
+    public function getBundleThemesAssetsPath($basePath, $bundleName)
+    {
+        return $basePath . DIRECTORY_SEPARATOR . preg_replace('/bundle$/', "", strtolower($bundleName));
+    }
+
+    /**
+     * Mirrors the content of $originDir in $targetDir
+     *     Inspired by symfony assets:install hardCopy.
      * @param string $originDir
      * @param string $targetDir
      */

--- a/Installer.php
+++ b/Installer.php
@@ -98,15 +98,15 @@ class Installer
             if($path) {
                 $originDir = $path;
                 $targetDir = $basePath . DIRECTORY_SEPARATOR . $theme;
-            }
 
-            $this->logger->notice(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $originDir, $targetDir));
+                $this->logger->notice(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $originDir, $targetDir));
+            }
         }
 
-        // Only link / mirror the public folder.
-        $originDir = realpath($originDir) . DIRECTORY_SEPARATOR . "public";
+        if (isset($originDir) && isset($targetDir)) {
+            // Only link / mirror the public folder.
+            $originDir = realpath($originDir) . DIRECTORY_SEPARATOR . "public";
 
-        if ($originDir && $targetDir) {
             if (!is_dir($originDir)) {
                 $this->logger->warning(sprintf("No assets to install for theme %s. <comment>Skipping.</comment>", $theme));
                 return false;
@@ -121,6 +121,8 @@ class Installer
             }
 
             return true;
+        } else {
+            $this->logger->warning(sprintf('Theme <comment>%s</comment> not found. <comment>Skipping.</comment>', $theme));
         }
     }
 

--- a/Installer.php
+++ b/Installer.php
@@ -60,10 +60,13 @@ class Installer
      * @param  string  $basePath Path to the target directory, defaults to 'web/themes'
      * @param  boolean $symlink  Whether make a symlink or hard copy
      */
-    public function installAssets($theme, $basePath = 'web/themes', $symlink=true)
+    public function installAssets($theme, $basePath = null, $symlink=true)
     {
-        if(!is_writable($basePath)) {
-            //
+        if(is_null($basePath)) {
+            $basePath = "web" . DIRECTORY_SEPARATOR . "themes";
+        }
+
+        if(file_exists($basePath) && !is_writable($basePath)) {
             throw new \InvalidArgumentException(
                 "'basePath' is not writable"
             );

--- a/Installer.php
+++ b/Installer.php
@@ -2,8 +2,9 @@
 
 namespace Liip\ThemeBundle;
 
-use Liip\ThemeBundle\Locator\ThemeLocator;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Liip\ThemeBundle\Locator\ThemeLocator;
 
 class Installer
 {
@@ -41,13 +42,13 @@ class Installer
         $this->filesystem->mkdir($basePath, 0777);
 
         // Search in bundles first.
-        $bundle = $this->themeLocator->locateThemeInBundles($theme);
-        if(!empty($bundle)) {
+        $pathInfos = $this->themeLocator->locateThemeInBundles($theme);
+        if(!empty($pathInfos)) {
             // Found theme in bundle.
-            $originDir = $bundle["path"];
+            $originDir = $pathInfos["path"];
 
             // Prepare the directory for this bundle.
-            $themesAssetsBundleDir = $this->getBundleThemesAssetsPath($basePath, $bundle["bundle"]->getName());
+            $themesAssetsBundleDir = $this->getBundleThemesAssetsPath($basePath, $pathInfos["bundle"]->getName());
             if(!is_dir($themesAssetsBundleDir)) {
                 $this->filesystem->mkdir($themesAssetsBundleDir, 0777);
             }

--- a/Installer.php
+++ b/Installer.php
@@ -66,6 +66,9 @@ class Installer
             // $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $originDir, $targetDir));
         }
 
+        // Only link / mirror the public folder.
+        $originDir = realpath($originDir) . DIRECTORY_SEPARATOR . "public";
+
         if($originDir && $targetDir) {
             if($symlink) {
                 // Symlink.

--- a/Installer.php
+++ b/Installer.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Liip\ThemeBundle;
+
+use Liip\ThemeBundle\Locator\ThemeLocator;
+use Symfony\Component\Filesystem\Filesystem;
+
+class Installer
+{
+    /**
+     * Locator service for themes.
+     * @var \Liip\ThemeBundle\Locator\ThemeLocator
+     */
+    protected $themeLocator;
+
+    /**
+     * Symfony filesystem service.
+     * @var \Symfony\Component\Filesystem\Filesystem
+     */
+    protected $filesystem;
+
+    public function __construct(ThemeLocator $themeLocator, Filesystem $filesystem)
+    {
+        $this->themeLocator = $themeLocator;
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Install assets for given $theme in $basePath
+     *
+     * @param  string  $theme    [description]
+     * @param  string  $basePath Path to the target directory, defaults to 'web/themes'
+     * @param  boolean $symlink  Whether make a symlink or hard copy
+     */
+    public function installAssets($theme, $basePath = 'web/themes', $symlink=true)
+    {
+        if(file_exists($basePath)) {
+            // Cleanup existing basePath folder, if needed.
+            $this->filesystem->remove($basePath);
+        }
+        $this->filesystem->mkdir($basePath, 0777);
+
+        // Search in bundles first.
+        $bundle = $this->themeLocator->locateThemeInBundles($theme);
+        if(!empty($bundle)) {
+            // Found theme in bundle.
+            $originDir = $bundle["path"];
+
+            // Prepare the directory for this bundle.
+            $themesAssetsBundleDir = $basePath . DIRECTORY_SEPARATOR . strtolower($bundle["bundle"]->getName());
+            if(!is_dir($themesAssetsBundleDir)) {
+                $this->filesystem->mkdir($themesAssetsBundleDir, 0777);
+            }
+
+            $targetDir = $themesAssetsBundleDir . DIRECTORY_SEPARATOR . $theme;
+
+            // $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $bundle["bundle"]->getName(), $targetDir));
+        } else {
+            // Search in app/
+            $path = $this->themeLocator->locateThemeInApp($theme);
+            if($path) {
+                $originDir = $path;
+                $targetDir = $appThemesDir . DIRECTORY_SEPARATOR . $theme;
+            }
+
+            // $output->writeln(sprintf('Found theme <comment>%s</comment> in <comment>%s</comment> installing in <comment>%s</comment> ', $theme, $originDir, $targetDir));
+        }
+
+        if($originDir && $targetDir) {
+            if($symlink) {
+                // Symlink.
+                $this->filesystem->symlink($originDir, $targetDir, true);
+            } else {
+                // Hard copy.
+                $this->hardCopy($originDir, $targetDir);
+            }
+        }
+    }
+
+    /**
+     * @param string $originDir
+     * @param string $targetDir
+     */
+    private function hardCopy($originDir, $targetDir)
+    {
+        $this->filesystem->mkdir($targetDir, 0777);
+        // We use a custom iterator to ignore VCS files
+        $this->filesystem->mirror($originDir, $targetDir, Finder::create()->ignoreDotFiles(false)->in($originDir));
+    }
+}

--- a/Installer.php
+++ b/Installer.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Liip/ThemeBundle
+ *
+ * (c) Liip AG
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Liip\ThemeBundle;
 
 use Symfony\Component\Filesystem\Filesystem;
@@ -7,6 +16,15 @@ use Symfony\Component\Finder\Finder;
 use Liip\ThemeBundle\Locator\ThemeLocator;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Theme installer service.
+ *
+ * This is a service so we can inject it as reference to different parts of the
+ * application. Can be used from command-line using assets:themes-install or to
+ * install assets after uploading a new theme in the app.
+ *
+ * @author adrienrn
+ */
 class Installer
 {
     /**

--- a/Locator/ThemeLocator.php
+++ b/Locator/ThemeLocator.php
@@ -1,12 +1,27 @@
 <?php
 
+/*
+ * This file is part of the Liip/ThemeBundle
+ *
+ * (c) Liip AG
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Liip\ThemeBundle\Locator;
 
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
+ * Theme locator to find themes inside a project.
  *
+ * Locate themes within the project using path patterns defined in liip_theme
+ * configuration This is a service so we can inject it as reference to different
+ * parts of the application.
+ *
+ * @author adrienrn
  */
 class ThemeLocator
 {

--- a/Locator/ThemeLocator.php
+++ b/Locator/ThemeLocator.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Liip\ThemeBundle\Locator;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ *
+ */
+class ThemeLocator
+{
+    protected $appPath;
+    protected $kernel;
+    protected $pathPatterns;
+
+    function __construct(KernelInterface $kernel, $appPath = null, array $pathPatterns = array())
+    {
+        $this->kernel = $kernel;
+        $this->appPath = $appPath;
+
+        $defaultPathPatterns = array(
+            'app_resource' => array(
+                '%app_path%/themes/%current_theme%/%template%',
+                '%app_path%/views/%template%',
+            ),
+            'bundle_resource' => array(
+                '%bundle_path%/Resources/themes/%current_theme%/%template%',
+            ),
+            'bundle_resource_dir' => array(
+                '%dir%/themes/%current_theme%/%bundle_name%/%template%',
+                '%dir%/%bundle_name%/%override_path%',
+            ),
+        );
+
+        $this->pathPatterns = array_merge_recursive(array_filter($pathPatterns), $defaultPathPatterns);
+    }
+
+    public function locate($theme, $dir = null, $first = true)
+    {
+        // @TODO
+    }
+
+    public function locateThemeInBundles($theme, $dir = null, $first = true)
+    {
+        $parameters = array(
+            '%app_path%' => $this->appPath,
+            '%dir%' => $dir,
+            '%override_path%' => $theme, // ?
+            '%current_theme%' => $theme,
+            '%current_device%' => "", // ?
+            '%template%' => ""
+        );
+
+        foreach($this->kernel->getBundles() as $bundle) {
+            $checkPaths = $this->getPathsForBundle(
+                array_merge(
+                    $parameters,
+                    array(
+                        '%bundle_path%' => $bundle->getPath(),
+                        '%bundle_name%' => $bundle->getName()
+                    )
+                )
+            );
+
+            $found = [];
+            foreach ($checkPaths as $checkPath) {
+                if (file_exists($checkPath)) {
+                    if ($first) {
+                        return array(
+                            "path" => $checkPath,
+                            "bundle" => $bundle
+                        );
+                    }
+                    $found[] = array(
+                        "path" => $checkPath,
+                        "bundle" => $bundle
+                    );
+                }
+            }
+        }
+
+        if (count($found) > 0 && $first) {
+            return $found[0];
+        }
+
+        return $found;
+    }
+
+    public function locateThemeInApp($theme, $dir = null, $first = true)
+    {
+        $files = array();
+        $parameters = array(
+            '%app_path%' => $this->appPath,
+            '%current_theme%' => $theme,
+            '%current_device%' => "", // ?
+            '%template%' => "",
+        );
+
+        foreach ($this->getPathsForAppResource($parameters) as $checkPath) {
+            if (file_exists($checkPath)) {
+                if ($first) {
+                    return $checkPath;
+                }
+                $files[] = $checkPath;
+            }
+        }
+
+        return $files;
+    }
+
+    protected function getPathsForBundle($parameters)
+    {
+        $pathPatterns = array();
+        $paths = array();
+
+        if (!empty($parameters['%dir%'])) {
+            $pathPatterns = array_merge($pathPatterns, $this->pathPatterns['bundle_resource_dir']);
+        }
+
+        $pathPatterns = array_merge($pathPatterns, $this->pathPatterns['bundle_resource']);
+
+        foreach ($pathPatterns as $pattern) {
+            $paths[] = strtr($pattern, $parameters);
+        }
+
+        return $paths;
+    }
+
+    protected function getPathsForAppResource($parameters)
+    {
+        $paths = array();
+
+        foreach ($this->pathPatterns['app_resource'] as $pattern) {
+            $paths[] = strtr($pattern, $parameters);
+        }
+
+        return $paths;
+    }
+}

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -7,6 +7,7 @@
         <parameter key="liip_theme.templating_locator.class">Liip\ThemeBundle\Locator\TemplateLocator</parameter>
         <parameter key="liip_theme.file_locator.class">Liip\ThemeBundle\Locator\FileLocator</parameter>
         <parameter key="liip_theme.filesystem_loader.class">Liip\ThemeBundle\Twig\Loader\FilesystemLoader</parameter>
+        <parameter key="liip_theme.theme_locator.class">Liip\ThemeBundle\Locator\ThemeLocator</parameter>
         <parameter key="liip_theme.active_theme.class">Liip\ThemeBundle\ActiveTheme</parameter>
         <parameter key="liip_theme.cache_warmer.class">Liip\ThemeBundle\CacheWarmer\TemplatePathsCacheWarmer</parameter>
         <parameter key="liip_theme.theme_auto_detect.class">Liip\ThemeBundle\Helper\DeviceDetection</parameter>
@@ -31,6 +32,12 @@
             <argument type="service" id="liip_theme.active_theme" />
             <argument>%kernel.root_dir%/Resources</argument>
             <argument type="collection" />
+            <argument>%liip_theme.path_patterns%</argument>
+        </service>
+
+        <service id="liip_theme.theme_locator" class="%liip_theme.theme_locator.class%">
+            <argument type="service" id="kernel" />
+            <argument>%kernel.root_dir%</argument>
             <argument>%liip_theme.path_patterns%</argument>
         </service>
 

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -47,6 +47,7 @@
             <argument>%liip_theme.active_theme%</argument>
             <argument>%liip_theme.themes%</argument>
             <argument type="service" id="liip_theme.theme_auto_detect" />
+            <argument type="service" id="liip_theme.theme_locator" />
         </service>
 
     </services>

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -8,6 +8,7 @@
         <parameter key="liip_theme.file_locator.class">Liip\ThemeBundle\Locator\FileLocator</parameter>
         <parameter key="liip_theme.filesystem_loader.class">Liip\ThemeBundle\Twig\Loader\FilesystemLoader</parameter>
         <parameter key="liip_theme.theme_locator.class">Liip\ThemeBundle\Locator\ThemeLocator</parameter>
+        <parameter key="liip_theme.installer.class">Liip\ThemeBundle\Installer</parameter>
         <parameter key="liip_theme.active_theme.class">Liip\ThemeBundle\ActiveTheme</parameter>
         <parameter key="liip_theme.cache_warmer.class">Liip\ThemeBundle\CacheWarmer\TemplatePathsCacheWarmer</parameter>
         <parameter key="liip_theme.theme_auto_detect.class">Liip\ThemeBundle\Helper\DeviceDetection</parameter>
@@ -39,6 +40,11 @@
             <argument type="service" id="kernel" />
             <argument>%kernel.root_dir%</argument>
             <argument>%liip_theme.path_patterns%</argument>
+        </service>
+
+        <service id="liip_theme.installer" class="%liip_theme.installer.class%">
+            <argument type="service" id="liip_theme.theme_locator" />
+            <argument type="service" id="filesystem" />
         </service>
 
         <service id="liip_theme.theme_auto_detect" class="%liip_theme.theme_auto_detect.class%" />

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -45,6 +45,7 @@
         <service id="liip_theme.installer" class="%liip_theme.installer.class%">
             <argument type="service" id="liip_theme.theme_locator" />
             <argument type="service" id="filesystem" />
+            <argument type="service" id="logger" on-invalid="null" />
         </service>
 
         <service id="liip_theme.theme_auto_detect" class="%liip_theme.theme_auto_detect.class%" />


### PR DESCRIPTION
First, thanks for the great work you've put in writing theme-bundle. It works great.

### Context

Working on a project close to a CMS, built on Symfony, our clients were asking was customizing the look-and-feel of the platform to match their brand identity.

That's how I stubbled upon this bundle and it works great but allow user to upload their theme including assets (CSS, JS, images) was the main struggle I encountered.

That's why I worked on a way to make those assets available in web/ directory. This might be a solution to some opened issues like #110.

### Solution

The solution is a command, similar to `assets:install`.

```bash
~ $ php app/console assets:themes-install --symlink web
```

Then you can use the `asset()` twig function to reference your asset as you would do with regular bundles assets.
 
If the theme is part of a bundle :

```twig
<link rel="stylesheet" type="text/css" href="{{ asset('themes/mybundle/mytheme/stylesheets/style.css') }}">
```

If the theme is inside the app/ directory :

```twig
<link rel="stylesheet" type="text/css" href="{{ asset('themes/mytheme/stylesheets/style.css') }}">
```

### Under the hood

Every theme ships its own assets in a `public/` directory. 

| Directory | Description |
|-----------|---------------|
| `public/` | Assets of this themes (images, javascripts, stylesheets, fonts, etc). It mimics the Symfony assets directory structure inside each themes. |
| `public/images/` | Holds all the static images of this theme. |
| `public/javascripts/` | Holds all the Javascript files of this theme. |
| `public/stylesheets/` | Holds the CSS files of this theme. |

The command makes symlinks (or hard copies) of assets into the `web/themes/` directory.

It takes the `liip_theme.themes` configuration and makes the right symlink – if a `public/` directory is found inside each theme.

If `liip_theme.themes` is not defined, it just scans the project, searching for themes in `liip_theme.path_patterns` paths.

### ThemeLocator & Installer.php

Discovering themes (dynamically) is possible by calling the service `liip_theme.theme_locator` and `ThemeLocator::discoverThemes()`.

Install assets of a theme is possible calling the service `liip_theme.installer` – that you can call after the upload of a theme and therefore dynamically install the assets of the theme (that's why I'm linking the issue #110).

---

What do you think ?


