### PR TITLE
TwigBundle fix. Incorrect paths for views @Twig/Exception/%s.%s.twig.

### DIFF
--- a/Locator/FileLocator.php
+++ b/Locator/FileLocator.php
@@ -134,6 +134,7 @@ class FileLocator extends BaseFileLocator
         if ('@' === $name[0]) {
             return $this->locateBundleResource($name, $this->path, $first);
         }
+
         if (0 === strpos($name, 'views/')) {
             if ($res = $this->locateAppResource($name, $this->path, $first)) {
                 return $res;
@@ -167,6 +168,13 @@ class FileLocator extends BaseFileLocator
         $path = '';
         if (false !== strpos($bundleName, '/')) {
             list($bundleName, $path) = explode('/', $bundleName, 2);
+        }
+
+        if (!preg_match('/(Bundle)$/i', $bundleName)) {
+            $bundleName .= 'Bundle';
+            if (0 !== strpos($path, 'Resources')) {
+                $path = 'Resources/views/' . $path;
+            }
         }
 
         if (0 !== strpos($path, 'Resources')) {

--- a/Locator/FileLocator.php
+++ b/Locator/FileLocator.php
@@ -173,7 +173,7 @@ class FileLocator extends BaseFileLocator
         if (!preg_match('/(Bundle)$/i', $bundleName)) {
             $bundleName .= 'Bundle';
             if (0 !== strpos($path, 'Resources')) {
-                $path = 'Resources/views/' . $path;
+                $path = 'Resources/views/'.$path;
             }
         }
 

--- a/Tests/Locator/FileLocatorTest.php
+++ b/Tests/Locator/FileLocatorTest.php
@@ -155,6 +155,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
 
         $file = $fileLocator->locate('@ThemeBundle/Resources/views/template', $this->getFixturePath(), true);
         $this->assertEquals($this->getFixturePath().'/Resources/themes/foo/template', $file);
+        $this->assertResourcesEquals($fileLocator, '@ThemeBundle/Resources/views/template', '@Theme/template');
     }
 
     /**
@@ -176,6 +177,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
 
         $file = $fileLocator->locate('@ThemeBundle/Resources/views/template', $this->getFixturePath(), true);
         $this->assertEquals($this->getFixturePath().'/Resources/views/themes/foo/template', $file);
+        $this->assertResourcesEquals($fileLocator, '@ThemeBundle/Resources/views/template', '@Theme/template');
 
         // Fall through user-configured cascade order - /Resources/views/themes/bar will not be found.
         $activeTheme = new ActiveTheme('bar', array('foo', 'bar', 'foobar'));
@@ -184,6 +186,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
 
         $file = $fileLocator->locate('@ThemeBundle/Resources/views/template', $this->getFixturePath(), true);
         $this->assertEquals($this->getFixturePath().'/Resources/views/themes/fallback/template', $file);
+        $this->assertResourcesEquals($fileLocator, '@ThemeBundle/Resources/views/template', '@Theme/template');
     }
 
     /**
@@ -198,6 +201,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
 
         $file = $fileLocator->locate('@ThemeBundle/Resources/views/foo', $this->getFixturePath(), true);
         $this->assertEquals($this->getFixturePath().'/rootdir/Resources/themes/foo/LiipMockLocateAppThemeOverridesAll/foo', $file);
+        $this->assertResourcesEquals($fileLocator, '@ThemeBundle/Resources/views/foo', '@Theme/foo');
     }
 
     /**
@@ -239,6 +243,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
 
         $file = $fileLocator->locate('@ThemeBundle/Resources/views/defaultTemplate', $this->getFixturePath(), true);
         $this->assertEquals($this->getFixturePath().'/Resources/views/phone/defaultTemplate', $file);
+        $this->assertResourcesEquals($fileLocator, '@ThemeBundle/Resources/views/defaultTemplate', '@Theme/defaultTemplate');
     }
 
     /**
@@ -285,6 +290,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
 
         $file = $fileLocator->locate('@ThemeBundle/Resources/views/defaultTemplate', $this->getFixturePath(), true);
         $this->assertEquals($this->getFixturePath().'/Resources/views/defaultTemplate', $file);
+        $this->assertResourcesEquals($fileLocator, '@ThemeBundle/Resources/views/defaultTemplate', '@Theme/defaultTemplate');
     }
 
     /**
@@ -304,6 +310,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
 
         $files = $fileLocator->locate('@ThemeBundle/Resources/views/template', $this->getFixturePath(), false);
         $this->assertEquals($expectedFiles, $files);
+        $this->assertResourcesEquals($fileLocator, '@ThemeBundle/Resources/views/template', '@Theme/template');
     }
 
     /**
@@ -350,6 +357,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
 
         $file = $fileLocator->locate('@ThemeBundle/Resources/views/rootTemplate', $this->getFixturePath(), true);
         $this->assertEquals($this->getFixturePath().'/rootdir/Resources/themes/foo/LiipMockLocateRootDirectory/rootTemplate', $file);
+        $this->assertResourcesEquals($fileLocator, '@ThemeBundle/Resources/views/rootTemplate', '@Theme/rootTemplate');
     }
 
     /**
@@ -364,6 +372,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
 
         $file = $fileLocator->locate('@ThemeBundle/Resources/views/override', $this->getFixturePath(), true);
         $this->assertEquals($this->getFixturePath().'/rootdir/Resources/LiipMockLocateOverrideDirectory/views/override', $file);
+        $this->assertResourcesEquals($fileLocator, '@ThemeBundle/Resources/views/override', '@Theme/override');
     }
 
     /**
@@ -439,5 +448,19 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
         ->will($this->returnValue(array()));
 
         $file = $fileLocator->locate('@ThemeBundle/Resources/nonExistant', $this->getFixturePath(), true);
+    }
+
+    /**
+     * Asserts that two resources are equal paths.
+     *
+     * @param FileLocator $fileLocator
+     * @param string      $expected
+     * @param string      $actual
+     * @param string      $message
+     */
+    private function assertResourcesEquals(FileLocator $fileLocator, $expected, $actual, $message = '')
+    {
+        $this->assertEquals($fileLocator->locate($expected, $this->getFixturePath(), true),
+            $fileLocator->locate($actual, $this->getFixturePath(), true), $message);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "phpunit/php-code-coverage": "~2.2@stable",
         "symfony/console": "~2.3|~3.0",
         "symfony/expression-language": "~2.6|~3.0",
+        "symfony/templating": "~2.3|~3.0",
         "kriswallsmith/assetic": "~1.1",
         "twig/twig": "~1.4|~2.0@dev"
     },


### PR DESCRIPTION
I had a similar problem as in issue https://github.com/liip/LiipThemeBundle/issues/146. The problem is use native template names in TwigBundle. It causes that I cannot override the error pages. 