### PR TITLE
reset theme after assetic loader has been called

### DIFF
--- a/Assetic/TwigFormulaLoader.php
+++ b/Assetic/TwigFormulaLoader.php
@@ -51,6 +51,8 @@ class TwigFormulaLoader extends BaseTwigFormulaLoader
         $failureTemplates = array();
         $successTemplates = array();
 
+        $previousTheme = $this->activeTheme->getName();
+
         foreach ($this->activeTheme->getThemes() as $theme) {
             $this->activeTheme->setName($theme);
 
@@ -70,6 +72,8 @@ class TwigFormulaLoader extends BaseTwigFormulaLoader
                 $failureTemplates[(string) $resource] = $e->getMessage();
             }
         }
+
+        $this->activeTheme->setName($previousTheme);
 
         if ($this->logger) {
             foreach ($failureTemplates as $failureTemplate => $exceptionMessage) {

--- a/Tests/Assetic/TwigFormulaLoaderTest.php
+++ b/Tests/Assetic/TwigFormulaLoaderTest.php
@@ -36,7 +36,15 @@ class TwigFormulaLoaderTest extends \PHPUnit_Framework_TestCase
      */
     private $resource;
 
+    /**
+     * @var string
+     */
     private $resourceContent;
+
+    /**
+     * @var TwigFormulaLoaderTest
+     */
+    private $loader;
 
     public function setUp()
     {
@@ -61,7 +69,9 @@ class TwigFormulaLoaderTest extends \PHPUnit_Framework_TestCase
             'theme1', 'theme2',
         ));
 
-        $this->activeTheme->setName('theme1')->shouldBeCalled();
+        $this->activeTheme->getName()->willReturn('theme1');
+
+        $this->activeTheme->setName('theme1')->shouldBeCalledTimes(2);
         $this->activeTheme->setName('theme2')->shouldBeCalled();
 
         $this->twig->tokenize(Argument::any(), Argument::any())->shouldBeCalled()->willReturn(new \Twig_TokenStream(array()));
@@ -75,6 +85,7 @@ class TwigFormulaLoaderTest extends \PHPUnit_Framework_TestCase
         $this->activeTheme->getThemes()->willReturn(array(
             'theme1',
         ));
+        $this->activeTheme->getName()->willReturn('theme1');
         $this->activeTheme->setName('theme1')->shouldBeCalled();
         $this->twig->tokenize(Argument::any())->willThrow(new \Exception('foobar'));
         $this->logger->error('The template "foo" contains an error: "foobar"')->shouldBeCalled();


### PR DESCRIPTION
I had a case where the `TwigFormulaLoader` was called somewhere in the middle of the request. Afterwards the active theme name was simply set to the last one, because the `TwigFormulaLoader` set all of them once.

This PR should fix it by resetting the value to whatever it was before.