### PR TITLE
Change the way to inject ActiveTheme since Symfony 3.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - SYMFONY_VERSION=2.7.*
 
 matrix:
+  fast_finish: true
   include:
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*
@@ -30,9 +31,14 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=3.2.*
     - php: 5.6
+      env: SYMFONY_VERSION=@dev
+    - php: 5.6
       env: TWIG_VERSION=2.x
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+  allow_failures:
+    - php: 5.6
+      env: SYMFONY_VERSION=@dev
 
 before_install:
   - if [[ ${TRAVIS_PHP_VERSION} != "hhvm" ]]; then phpenv config-add travis.php.ini; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=3.0.*
     - php: 5.6
+      env: SYMFONY_VERSION=3.1.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.2.*
+    - php: 5.6
       env: TWIG_VERSION=2.x
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"

--- a/DependencyInjection/Compiler/ThemeCompilerPass.php
+++ b/DependencyInjection/Compiler/ThemeCompilerPass.php
@@ -30,6 +30,6 @@ class ThemeCompilerPass implements CompilerPassInterface
 
         $twigFilesystemLoaderDefinition = $container->getDefinition('twig.loader.filesystem');
         $twigFilesystemLoaderDefinition->setClass($container->getParameter('liip_theme.filesystem_loader.class'));
-        $twigFilesystemLoaderDefinition->addMethodCall('setActiveTheme', [new Reference('liip_theme.active_theme')]);
+        $twigFilesystemLoaderDefinition->addMethodCall('setActiveTheme', array(new Reference('liip_theme.active_theme')));
     }
 }

--- a/DependencyInjection/Compiler/ThemeCompilerPass.php
+++ b/DependencyInjection/Compiler/ThemeCompilerPass.php
@@ -30,6 +30,6 @@ class ThemeCompilerPass implements CompilerPassInterface
 
         $twigFilesystemLoaderDefinition = $container->getDefinition('twig.loader.filesystem');
         $twigFilesystemLoaderDefinition->setClass($container->getParameter('liip_theme.filesystem_loader.class'));
-        $twigFilesystemLoaderDefinition->addArgument(new Reference('liip_theme.active_theme'));
+        $twigFilesystemLoaderDefinition->addMethodCall('setActiveTheme', [new Reference('liip_theme.active_theme')]);
     }
 }

--- a/Twig/Loader/FilesystemLoader.php
+++ b/Twig/Loader/FilesystemLoader.php
@@ -19,15 +19,27 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
     /**
      * Constructor.
      *
-     * @param FileLocatorInterface        $locator     A FileLocatorInterface instance
-     * @param TemplateNameParserInterface $parser      A TemplateNameParserInterface instance
-     * @param ActiveTheme                 $activeTheme
+     * @see TwigBundle own FilesystemLoader
+     *
+     * @param FileLocatorInterface        $locator  A FileLocatorInterface instance
+     * @param TemplateNameParserInterface $parser   A TemplateNameParserInterface instance
+     * @param string|null                 $rootPath The root path common to all relative paths (null for getcwd())
      */
-    public function __construct(FileLocatorInterface $locator, TemplateNameParserInterface $parser, ActiveTheme $activeTheme = null)
+    public function __construct(FileLocatorInterface $locator, TemplateNameParserInterface $parser, $rootPath = null)
     {
-        parent::__construct(array());
+        parent::__construct(array(), $rootPath);
+
         $this->locator = $locator;
         $this->parser = $parser;
+    }
+
+    /**
+     * Define the active theme
+     *
+     * @param ActiveTheme $activeTheme
+     */
+    public function setActiveTheme(ActiveTheme $activeTheme = null)
+    {
         $this->activeTheme = $activeTheme;
     }
 


### PR DESCRIPTION
In Symfonny 3.2.1 a new parameter has been added to the TwigBundle FilesystemLoader breaking the LiipThemeBundle own FilesystemLoader.
Instead of adding a 4th parameter, we define the service to call a method after being instanciated to define the ActiveTheme.

Related:
- https://github.com/liip/LiipThemeBundle/issues/157
- https://github.com/liip/LiipThemeBundle/pull/158
- https://github.com/symfony/symfony/pull/20727

I don't know if this provide a BC break since we are changing the constructor definition..