### PR TITLE
use PHP 7 for Twig 2.x builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
       env: SYMFONY_VERSION=3.2.*
     - php: 5.6
       env: SYMFONY_VERSION=@dev
-    - php: 5.6
+    - php: 7.0
       env: TWIG_VERSION=2.x
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"


### PR DESCRIPTION
Twig 2.0 dropped support for PHP < 7.0.