### PR TITLE
Bugfix FS Loader

### DIFF
--- a/Twig/Loader/FilesystemLoader.php
+++ b/Twig/Loader/FilesystemLoader.php
@@ -71,16 +71,17 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
 
         $file = null;
         $previous = null;
+
         try {
-            $file = parent::findTemplate((string) $template);
-        } catch (\Twig_Error_Loader $e) {
+            $template = $this->parser->parse($template);
+            $file = $this->locator->locate($template);
+        } catch (\Exception $e) {
             $previous = $e;
 
             // for BC
             try {
-                $template = $this->parser->parse($template);
-                $file = $this->locator->locate($template);
-            } catch (\Exception $e) {
+                $file = parent::findTemplate((string) $template);
+            } catch (\Twig_Error_Loader $e) {
                 $previous = $e;
             }
         }


### PR DESCRIPTION
Due to the changes in FOSUserBundle (https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2378) the overriding of themes stopped working in some cases.

I digged into the code with 2 cases:

1. New way of FOSUserBundle with Template `@FOSUser/Security/login.html.twig`

Does not work since the call to `$file = parent::findTemplate((string) $template);` resolves a proper template not concerning the theme. However included templates do take the theme into account.

2. The old way with template `FOSUserBundle:Security:login.html.twig`

`$file = parent::findTemplate((string) $template);` throws an Exception which I do not understand, but the call to the parser and locater are resolving the proper template. 

Reodering as done with this PR fixes that issue.

Potential side effects might be performance as the custom logic has a higher priority than the SF loader.

It is also strange that this has no effect on tests.

Tickets:
- fixes #164 
