### PR TITLE
Upgrade to phpunit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [ "$TWIG_VERSION" != "" ]; then composer require twig/twig:$TWIG_VERSION --no-update; fi
-  - if [ "$DEPENDENCIES" != "" ]; then composer config minimum-stability $DEPENDENCES; fi;
+  - if [ "$DEPENDENCIES" != "" ]; then composer config minimum-stability $DEPENDENCIES; fi;
 
 install: composer update --prefer-source $COMPOSER_FLAGS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
       env: TWIG_VERSION=2.x
     - php: 7.0
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.1
+      env: DEPENDENCIES=beta
   allow_failures:
     - php: 5.6
       env: SYMFONY_VERSION=@dev
@@ -44,6 +46,7 @@ before_install:
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [ "$TWIG_VERSION" != "" ]; then composer require twig/twig:$TWIG_VERSION --no-update; fi
+  - if [ "$DEPENDENCIES" = "beta" ]; then perl -pi -e 's/^}$/,"minimum-stability":"beta"}/' composer.json; fi;
 
 install: composer update --prefer-source $COMPOSER_FLAGS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [ "$TWIG_VERSION" != "" ]; then composer require twig/twig:$TWIG_VERSION --no-update; fi
-  - if [ "$DEPENDENCIES" = "beta" ]; then perl -pi -e 's/^}$/,"minimum-stability":"beta"}/' composer.json; fi;
+  - if [ "$DEPENDENCIES" != "" ]; then composer config minimum-stability $DEPENDENCES; fi;
 
 install: composer update --prefer-source $COMPOSER_FLAGS
 

--- a/Tests/ActiveThemeTest.php
+++ b/Tests/ActiveThemeTest.php
@@ -14,7 +14,7 @@ namespace Liip\Tests;
 use Liip\ThemeBundle\Helper\DeviceDetection;
 use Liip\ThemeBundle\ActiveTheme;
 
-class ActiveThemeTest extends \PHPUnit_Framework_TestCase
+class ActiveThemeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers Liip\ThemeBundle\ActiveTheme::__construct

--- a/Tests/Assetic/TwigFormulaLoaderTest.php
+++ b/Tests/Assetic/TwigFormulaLoaderTest.php
@@ -14,7 +14,7 @@ namespace Liip\ThemeBundle\Tests\Assetic;
 use Liip\ThemeBundle\Assetic\TwigFormulaLoader;
 use Prophecy\Argument;
 
-class TwigFormulaLoaderTest extends \PHPUnit_Framework_TestCase
+class TwigFormulaLoaderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Prophecy\Prophecy\ObjectProphecy

--- a/Tests/CacheWarmer/TemplateFinderTest.php
+++ b/Tests/CacheWarmer/TemplateFinderTest.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\TemplateFilenameParser;
  *
  * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
  */
-class TemplateFinderTest extends \PHPUnit_Framework_TestCase
+class TemplateFinderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\HttpKernel\KernelInterface

--- a/Tests/CacheWarmer/TemplatePathsCacheWarmerTest.php
+++ b/Tests/CacheWarmer/TemplatePathsCacheWarmerTest.php
@@ -17,7 +17,7 @@ use Liip\ThemeBundle\CacheWarmer\TemplatePathsCacheWarmer;
  *
  * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
  */
-class TemplatePathsCacheWarmerTest extends \PHPUnit_Framework_TestCase
+class TemplatePathsCacheWarmerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinderInterface

--- a/Tests/DependencyInjection/Compiler/AsseticTwigFormulaPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AsseticTwigFormulaPassTest.php
@@ -22,8 +22,14 @@ class AsseticTwigFormulaPassTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
-        $this->definition = $this->createMock('Symfony\Component\DependencyInjection\Definition');
+        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->definition = $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
         $this->pass = new AsseticTwigFormulaPass();
     }
 

--- a/Tests/DependencyInjection/Compiler/AsseticTwigFormulaPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AsseticTwigFormulaPassTest.php
@@ -14,7 +14,7 @@ namespace Liip\ThemeBundle\Tests\DependencyInjection;
 use Symfony\Component\DependencyInjection\Definition;
 use Liip\ThemeBundle\DependencyInjection\Compiler\AsseticTwigFormulaPass;
 
-class AsseticTwigFormulaPassTest extends \PHPUnit_Framework_TestCase
+class AsseticTwigFormulaPassTest extends \PHPUnit\Framework\TestCase
 {
     private $container;
     private $definition;

--- a/Tests/DependencyInjection/Compiler/AsseticTwigFormulaPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AsseticTwigFormulaPassTest.php
@@ -22,8 +22,8 @@ class AsseticTwigFormulaPassTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
-        $this->definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $this->definition = $this->createMock('Symfony\Component\DependencyInjection\Definition');
         $this->pass = new AsseticTwigFormulaPass();
     }
 

--- a/Tests/DependencyInjection/Compiler/ThemeCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ThemeCompilerPassTest.php
@@ -4,7 +4,7 @@ namespace Liip\ThemeBundle\Tests\DependencyInjection;
 
 use Liip\ThemeBundle\DependencyInjection\Compiler\ThemeCompilerPass;
 
-class ThemeCompilerPassTest extends \PHPUnit_Framework_TestCase
+class ThemeCompilerPassTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers Liip\ThemeBundle\DependencyInjection\Compiler\ThemeCompilerPass::process

--- a/Tests/DependencyInjection/Compiler/ThemeCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ThemeCompilerPassTest.php
@@ -11,7 +11,9 @@ class ThemeCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcess()
     {
-        $containerMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $containerMock->expects($this->exactly(2))
             ->method('setAlias')
@@ -31,7 +33,11 @@ class ThemeCompilerPassTest extends \PHPUnit_Framework_TestCase
         $containerMock->expects($this->once())
             ->method('getDefinition')
             ->with('twig.loader.filesystem')
-            ->willReturn($this->createMock('Symfony\Component\DependencyInjection\Definition'))
+            ->willReturn(
+                $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')
+                    ->disableOriginalConstructor()
+                    ->getMock()
+            )
         ;
 
         $themeCompiler = new ThemeCompilerPass();

--- a/Tests/DependencyInjection/Compiler/ThemeCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ThemeCompilerPassTest.php
@@ -11,7 +11,7 @@ class ThemeCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcess()
     {
-        $containerMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
 
         $containerMock->expects($this->exactly(2))
             ->method('setAlias')
@@ -31,7 +31,7 @@ class ThemeCompilerPassTest extends \PHPUnit_Framework_TestCase
         $containerMock->expects($this->once())
             ->method('getDefinition')
             ->with('twig.loader.filesystem')
-            ->willReturn($this->getMock('Symfony\Component\DependencyInjection\Definition'))
+            ->willReturn($this->createMock('Symfony\Component\DependencyInjection\Definition'))
         ;
 
         $themeCompiler = new ThemeCompilerPass();

--- a/Tests/DependencyInjection/LiipThemeExtensionTest.php
+++ b/Tests/DependencyInjection/LiipThemeExtensionTest.php
@@ -5,7 +5,7 @@ namespace Liip\ThemeBundle\Tests\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Liip\ThemeBundle\DependencyInjection\LiipThemeExtension;
 
-class LiipThemeExtensionTest extends \PHPUnit_Framework_TestCase
+class LiipThemeExtensionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers Liip\ThemeBundle\LiipThemeBundle

--- a/Tests/EventListener/ThemeControllerListenerTest.php
+++ b/Tests/EventListener/ThemeControllerListenerTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 /**
  * @author David Buchmann <david@liip.ch>
  */
-class ThemeControllerListenerTest extends \PHPUnit_Framework_TestCase
+class ThemeControllerListenerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Request

--- a/Tests/EventListener/ThemeRequestListenerTest.php
+++ b/Tests/EventListener/ThemeRequestListenerTest.php
@@ -19,7 +19,7 @@ use Liip\ThemeBundle\EventListener\ThemeRequestListener;
  * @author Tobias Ebnöther <ebi@liip.ch>
  * @author Pascal Helfenstein <pascal@liip.ch>
  */
-class ThemeRequestListenerTest extends \PHPUnit_Framework_TestCase
+class ThemeRequestListenerTest extends \PHPUnit\Framework\TestCase
 {
     protected $testCookieName = 'LiipThemeRequestCookieTestName';
 

--- a/Tests/Helper/DeviceDetectionTest.php
+++ b/Tests/Helper/DeviceDetectionTest.php
@@ -13,7 +13,7 @@ namespace Liip\ThemeBundle\Tests\Helper;
 
 use Liip\ThemeBundle\Helper\DeviceDetection;
 
-class DeviceDetectionTest extends \PHPUnit_Framework_TestCase
+class DeviceDetectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers Liip\ThemeBundle\Helper\DeviceDetection::__construct
@@ -36,7 +36,7 @@ class DeviceDetectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error_Warning
+     * @expectedException \PHPUnit\Framework\Error\Warning
      */
     public function testCallError()
     {

--- a/Tests/LiipThemeBundleTest.php
+++ b/Tests/LiipThemeBundleTest.php
@@ -20,7 +20,10 @@ class LiipThemeBundleTest extends \PHPUnit_Framework_TestCase
      */
     public function testBuild()
     {
-        $containerMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerMock = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
         $containerMock->expects($this->exactly(3))
             ->method('addCompilerPass')
         ;

--- a/Tests/LiipThemeBundleTest.php
+++ b/Tests/LiipThemeBundleTest.php
@@ -13,7 +13,7 @@ namespace Liip\Tests;
 
 use Liip\ThemeBundle\LiipThemeBundle;
 
-class LiipThemeBundleTest extends \PHPUnit_Framework_TestCase
+class LiipThemeBundleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers Liip\ThemeBundle\LiipThemeBundle::build

--- a/Tests/LiipThemeBundleTest.php
+++ b/Tests/LiipThemeBundleTest.php
@@ -20,7 +20,7 @@ class LiipThemeBundleTest extends \PHPUnit_Framework_TestCase
      */
     public function testBuild()
     {
-        $containerMock = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerMock = $this->createMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $containerMock->expects($this->exactly(3))
             ->method('addCompilerPass')
         ;

--- a/Tests/Locator/FileLocatorTest.php
+++ b/Tests/Locator/FileLocatorTest.php
@@ -427,11 +427,11 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
         $kernel = $this->getKernelMock(true);
         $activeTheme = new ActiveTheme('bar', array('foo', 'bar', 'foobar'));
 
-        $fileLocator = $this->getMock(
-            'Liip\ThemeBundle\Locator\FileLocator',
-            array('getPathsForBundleResource'),
-            array($kernel, $activeTheme, $this->getFixturePath().'/rootdir/Resources')
-        );
+        $fileLocator = $this->getMockBuilder('Liip\ThemeBundle\Locator\FileLocator')
+            ->setConstructorArgs([$kernel, $activeTheme, $this->getFixturePath().'/rootdir/Resources'])
+            ->setMethods(['getPathsForBundleResource'])
+            ->getMock()
+        ;
 
         $fileLocator->expects($this->at(0))
         ->method('getPathsForBundleResource')

--- a/Tests/Locator/FileLocatorTest.php
+++ b/Tests/Locator/FileLocatorTest.php
@@ -20,7 +20,7 @@ class FileLocatorFake extends FileLocator
     public $lastTheme;
 }
 
-class FileLocatorTest extends \PHPUnit_Framework_TestCase
+class FileLocatorTest extends \PHPUnit\Framework\TestCase
 {
     protected function getKernelMock($includeDerivedBundle = false)
     {

--- a/Tests/Twig/Loader/FilesystemLoaderTest.php
+++ b/Tests/Twig/Loader/FilesystemLoaderTest.php
@@ -6,7 +6,7 @@ use Liip\ThemeBundle\ActiveTheme;
 use Liip\ThemeBundle\Twig\Loader\FilesystemLoader;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 
-class FilesystemLoaderTest extends \PHPUnit_Framework_TestCase
+class FilesystemLoaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetSourceContextWithLocator()
     {

--- a/Tests/UseCaseTest.php
+++ b/Tests/UseCaseTest.php
@@ -22,7 +22,7 @@ use Liip\ThemeBundle\ActiveTheme;
  *
  * @author Giulio De Donato <liuggio@gmail.com>
  */
-class UseCaseTest extends \PHPUnit_Framework_TestCase
+class UseCaseTest extends \PHPUnit\Framework\TestCase
 {
     protected $testCookieName = 'LiipThemeRequestCookieTestName';
 

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,16 @@
         }
     ],
     "require": {
-        "php": "^5.3.9|^7.0",
-        "symfony/framework-bundle": "~2.3|~3.0",
-        "symfony/finder": "~2.3|~3.0",
+        "php": "^5.3.9|^7.0|^7.1",
+        "symfony/framework-bundle": "~2.3|~3.0|~4.0",
+        "symfony/finder": "~2.3|~3.0|~4.0",
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "symfony/console": "~2.3|~3.0",
-        "symfony/expression-language": "~2.6|~3.0",
-        "symfony/templating": "~2.3|~3.0",
         "phpunit/phpunit": "~5.7",
+        "symfony/console": "~2.3|~3.0|~4.0",
+        "symfony/expression-language": "~2.6|~3.0|~4.0",
+        "symfony/templating": "~2.3|~3.0|~4.0",
         "kriswallsmith/assetic": "~1.1",
         "twig/twig": "~1.27|~2.0@dev"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "~4.5|~5.7",
         "symfony/console": "~2.3|~3.0|~4.0",
         "symfony/expression-language": "~2.6|~3.0|~4.0",
         "symfony/templating": "~2.3|~3.0|~4.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5|~5.7",
+        "phpunit/phpunit": "^4.8.35|^6.0",
         "symfony/console": "~2.3|~3.0|~4.0",
         "symfony/expression-language": "~2.6|~3.0|~4.0",
         "symfony/templating": "~2.3|~3.0|~4.0",

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,10 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
-        "phpunit/php-code-coverage": "~2.2",
         "symfony/console": "~2.3|~3.0",
         "symfony/expression-language": "~2.6|~3.0",
         "symfony/templating": "~2.3|~3.0",
+        "phpunit/phpunit": "~5.7",
         "kriswallsmith/assetic": "~1.1",
         "twig/twig": "~1.27|~2.0@dev"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.9|^7.0|^7.1",
+        "php": "^5.3.9|^7.0",
         "symfony/framework-bundle": "~2.3|~3.0|~4.0",
         "symfony/finder": "~2.3|~3.0|~4.0",
         "psr/log": "~1.0"


### PR DESCRIPTION
As suggested by @xabbuh in #171 

On PHP 5.5 a test is failing because it expects it to throw a `\PHPUnit\Framework\Error\Warning`, which wasn't added (nor is it planned to) to `phpunit@4.8`'s forward compatibility ([related phpunit issue](https://github.com/sebastianbergmann/phpunit/issues/2503)). I don't know how to move on about this...