### PR TITLE
Do not trigger getBundle deprecation notice

### DIFF
--- a/Locator/FileLocator.php
+++ b/Locator/FileLocator.php
@@ -182,7 +182,7 @@ class FileLocator extends BaseFileLocator
         }
 
         $resourceBundle = null;
-        $bundles = $this->kernel->getBundle($bundleName, false);
+        $bundles = $this->kernel->getBundle($bundleName, false, true);
         // Symfony 4+ no longer supports inheritance and so we only get a single bundle
         if (!is_array($bundles)) {
             $bundles = array($bundles);


### PR DESCRIPTION
As we supported SF4 I propose to not trigger the getBundle deprecation notice.