### PR TITLE
Symfony 4.1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
       env: SYMFONY_VERSION=@dev;ASSETIC=skip
 
 before_install:
+  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then phpenv config-add travis.php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != '7.0' && $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;

--- a/DependencyInjection/Compiler/ThemeCompilerPass.php
+++ b/DependencyInjection/Compiler/ThemeCompilerPass.php
@@ -30,6 +30,10 @@ class ThemeCompilerPass implements CompilerPassInterface
 
         $twigFilesystemLoaderDefinition = $container->findDefinition('twig.loader.filesystem');
         $twigFilesystemLoaderDefinition->setClass($container->getParameter('liip_theme.filesystem_loader.class'));
+        $twigFilesystemLoaderDefinition->setArguments(array(
+            $container->getDefinition('liip_theme.templating_locator'),
+            $container->getDefinition('templating.filename_parser')
+        ));
         $twigFilesystemLoaderDefinition->addMethodCall('setActiveTheme', array(new Reference('liip_theme.active_theme')));
     }
 }

--- a/DependencyInjection/Compiler/ThemeCompilerPass.php
+++ b/DependencyInjection/Compiler/ThemeCompilerPass.php
@@ -28,7 +28,7 @@ class ThemeCompilerPass implements CompilerPassInterface
                 ->replaceArgument(2, null);
         }
 
-        $twigFilesystemLoaderDefinition = $container->getDefinition('twig.loader.filesystem');
+        $twigFilesystemLoaderDefinition = $container->findDefinition('twig.loader.filesystem');
         $twigFilesystemLoaderDefinition->setClass($container->getParameter('liip_theme.filesystem_loader.class'));
         $twigFilesystemLoaderDefinition->addMethodCall('setActiveTheme', array(new Reference('liip_theme.active_theme')));
     }

--- a/Resources/config/templating.xml
+++ b/Resources/config/templating.xml
@@ -15,6 +15,8 @@
             <argument type="service" id="liip_theme.active_theme" />
         </service>
 
+        <service id="templating.filename_parser" class="Symfony\Bundle\FrameworkBundle\Templating\TemplateFilenameParser"/>
+
         <service id="templating.finder" class="Liip\ThemeBundle\CacheWarmer\TemplateFinder" public="false">
             <argument type="service" id="kernel" />
             <argument type="service" id="templating.filename_parser" />

--- a/Tests/DependencyInjection/Compiler/ThemeCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ThemeCompilerPassTest.php
@@ -31,7 +31,7 @@ class ThemeCompilerPassTest extends \PHPUnit\Framework\TestCase
         ;
 
         $containerMock->expects($this->once())
-            ->method('getDefinition')
+            ->method('findDefinition')
             ->with('twig.loader.filesystem')
             ->willReturn(
                 $this->getMockBuilder('Symfony\Component\DependencyInjection\Definition')

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = -1


### PR DESCRIPTION
Hi there,
on Symfony 4.1 there is some errors with this bundle:
1. Replace method `getDefinition` by `findDefinition`  to fix error: **You have requested a non-existent service "twig.loader.filesystem"**
2. Declare service locally `templating.filename_parser` to fix error: **You have requested a non-existent service "templating.filename_parser".**
3. Set missing arguments for class **\Liip\ThemeBundle\Twig\Loader\FilesystemLoader**