### PR TITLE
Twig deprecation notice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 sudo: false
 
@@ -13,13 +13,11 @@ cache:
     - $HOME/.composer/cache/files
 
 env:
-  - SYMFONY_VERSION=2.7.*
+  - SYMFONY_VERSION=3.0.*
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
-      env: SYMFONY_VERSION=2.8.*
     - php: 7.2
       env: SYMFONY_VERSION=3.3.*
     - php: 7.2
@@ -30,10 +28,18 @@ matrix:
       env: SYMFONY_VERSION=4.1.*;ASSETIC=skip
     - php: 7.2
       env: SYMFONY_VERSION=@dev;ASSETIC=skip
+    - php: 7.3
+    env: SYMFONY_VERSION=3.3.*
+    - php: 7.3
+      env: SYMFONY_VERSION=3.4.*
+    - php: 7.3
+      env: SYMFONY_VERSION=4.0.*;ASSETIC=skip
+    - php: 7.3
+      env: SYMFONY_VERSION=4.1.*;ASSETIC=skip
+    - php: 7.3
+      env: SYMFONY_VERSION=@dev;ASSETIC=skip
     - php: 7.0
-      env: TWIG_VERSION=2.x
-    - php: 5.6
-      env: COMPOSER_FLAGS="--prefer-lowest"
+      env: TWIG_VERSION=2.7.*
     - php: 7.1
       env: DEPENDENCIES=beta
   allow_failures:
@@ -41,8 +47,6 @@ matrix:
       env: SYMFONY_VERSION=@dev;ASSETIC=skip
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then phpenv config-add travis.php.ini; fi
-  - if [[ $TRAVIS_PHP_VERSION != '7.0' && $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [ "$ASSETIC" != "skip" ]; then composer require "kriswallsmith/assetic:^1.1" --no-update; fi;

--- a/Assetic/TwigFormulaLoader.php
+++ b/Assetic/TwigFormulaLoader.php
@@ -15,6 +15,8 @@ use Assetic\Factory\Resource\ResourceInterface;
 use Psr\Log\LoggerInterface;
 use Liip\ThemeBundle\ActiveTheme;
 use Assetic\Extension\Twig\TwigFormulaLoader as BaseTwigFormulaLoader;
+use Twig\Environment as TwigEnvironment;
+use Twig\Source as TwigSource;
 
 /**
  * Extends the base twig formula loader but iterates over all the
@@ -32,7 +34,7 @@ class TwigFormulaLoader extends BaseTwigFormulaLoader
     private $logger;
 
     public function __construct(
-        \Twig_Environment $twig,
+        TwigEnvironment $twig,
         LoggerInterface $logger = null,
         ActiveTheme $activeTheme = null
     ) {
@@ -58,8 +60,8 @@ class TwigFormulaLoader extends BaseTwigFormulaLoader
 
             try {
                 // determine if the template has any errors
-                if (class_exists('Twig_Source')) {
-                    $content = new \Twig_Source($resource->getContent(), (string) $resource->getContent());
+                if (class_exists(TwigSource::class)) {
+                    $content = new TwigSource($resource->getContent(), (string) $resource->getContent());
                 } else {
                     $content = $resource->getContent();
                 }

--- a/Tests/Assetic/TwigFormulaLoaderTest.php
+++ b/Tests/Assetic/TwigFormulaLoaderTest.php
@@ -52,7 +52,7 @@ class TwigFormulaLoaderTest extends \PHPUnit\Framework\TestCase
             $this->markTestSkipped('Assetic not supported');
         }
 
-        $this->twig = $this->prophesize('Twig_Environment');
+        $this->twig = $this->prophesize(\Twig\Environment::class);
         $this->activeTheme = $this->prophesize('Liip\ThemeBundle\ActiveTheme');
         $this->logger = $this->prophesize('Psr\Log\LoggerInterface');
         $this->resource = $this->prophesize('Assetic\Factory\Resource\ResourceInterface');
@@ -78,8 +78,8 @@ class TwigFormulaLoaderTest extends \PHPUnit\Framework\TestCase
         $this->activeTheme->setName('theme1')->shouldBeCalledTimes(2);
         $this->activeTheme->setName('theme2')->shouldBeCalled();
 
-        $this->twig->tokenize(Argument::any(), Argument::any())->shouldBeCalled()->willReturn(new \Twig_TokenStream(array()));
-        $this->twig->parse(Argument::any())->shouldBeCalled()->willReturn(new \Twig_Node);
+        $this->twig->tokenize(Argument::any(), Argument::any())->shouldBeCalled()->willReturn(new \Twig\TokenStream(array()));
+        $this->twig->parse(Argument::any())->shouldBeCalled()->willReturn(new \Twig\Node\Node);
 
         $this->loader->load($this->resource->reveal());
     }

--- a/Tests/Twig/Loader/FilesystemLoaderTest.php
+++ b/Tests/Twig/Loader/FilesystemLoaderTest.php
@@ -47,7 +47,7 @@ class FilesystemLoaderTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \Twig_Error_Loader
+     * @expectedException \Twig\Error\LoaderError
      */
     public function testTwigErrorIfLocatorThrowsInvalid()
     {

--- a/Twig/Loader/FilesystemLoader.php
+++ b/Twig/Loader/FilesystemLoader.php
@@ -6,8 +6,10 @@ use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Templating\TemplateNameParserInterface;
 use Symfony\Component\Templating\TemplateReferenceInterface;
 use Liip\ThemeBundle\ActiveTheme;
+use Twig\Error\LoaderError as TwigLoaderError;
+use Twig\Loader\FilesystemLoader as TwigFilesystemLoader;
 
-class FilesystemLoader extends \Twig_Loader_Filesystem
+class FilesystemLoader extends TwigFilesystemLoader
 {
     protected $locator;
     protected $parser;
@@ -52,11 +54,11 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
      * Otherwise the template is located using the locator from the twig library.
      *
      * @param string|TemplateReferenceInterface $template The template
-     * @param bool                              $throw    When true, a \Twig_Error_Loader exception will be thrown if a template could not be found
+     * @param bool                              $throw    When true, a \Twig\Error\LoaderError exception will be thrown if a template could not be found
      *
      * @return string The path to the template file
      *
-     * @throws \Twig_Error_Loader if the template could not be found
+     * @throws \Twig\Error\LoaderError if the template could not be found
      */
     protected function findTemplate($template, $throw = true)
     {
@@ -82,14 +84,14 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
             // for BC
             try {
                 $file = parent::findTemplate((string) $template);
-            } catch (\Twig_Error_Loader $e) {
+            } catch (TwigLoaderError $e) {
                 $previous = $e;
             }
         }
 
         if (false === $file || null === $file) {
             if ($throw) {
-                throw new \Twig_Error_Loader(sprintf('Unable to find template "%s".', $logicalName), -1, null, $previous);
+                throw new TwigLoaderError(sprintf('Unable to find template "%s".', $logicalName), -1, null, $previous);
             }
             
             return false;

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/finder": "^3.0|^4.0",
         "symfony/twig-bundle": "^3.0|^4.0",
         "symfony/templating": "^3.0|^4.0",
-        "twig/twig": ">=2.7",
+        "twig/twig": "^1.34|^2.4",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
         }
     ],
     "require": {
-        "php": "^5.3.9|^7.0",
-        "symfony/framework-bundle": "^2.7|^3.0|^4.0",
-        "symfony/finder": "^2.7|^3.0|^4.0",
-        "symfony/twig-bundle": "^2.7|^3.0|^4.0",
-        "symfony/templating": "^2.7|^3.0|^4.0",
-        "twig/twig": "^1.27|^2.0",
+        "php": "^7.0",
+        "symfony/framework-bundle": "^3.0|^4.0",
+        "symfony/finder": "^3.0|^4.0",
+        "symfony/twig-bundle": "^3.0|^4.0",
+        "symfony/templating": "^3.0|^4.0",
+        "twig/twig": ">=2.7",
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35|^6.0",
-        "symfony/console": "^2.7|^3.0|^4.0",
-        "symfony/expression-language": "^2.7|^3.0|^4.0"
+        "phpunit/phpunit": "^6.0",
+        "symfony/console": "^3.0|^4.0",
+        "symfony/expression-language": "^3.0|^4.0"
     },
     "autoload": {
         "psr-4": { "Liip\\ThemeBundle\\": "" }


### PR DESCRIPTION
This Pull Request fix all Twig deprecation notices when using Twig `>= 2.7` who now use namespaces.
However to achieve this, the support for SF2.7, PHP5.x and Twig < 2.7 has been dropped.