### PR TITLE
Fixing InvalidArgumentException with 'Cannot redirect to an empty URL'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.phar
 composer.lock
 phpunit.xml
+/.idea

--- a/Controller/ThemeController.php
+++ b/Controller/ThemeController.php
@@ -73,8 +73,7 @@ class ThemeController
 
         $this->activeTheme->setName($theme);
 
-        $url = $request->headers->get('Referer', '/');
-        $response = new RedirectResponse($url);
+        $response = new RedirectResponse($this->extractUrl($request));
 
         if (!empty($this->cookieOptions)) {
             $cookie = new Cookie(
@@ -91,5 +90,17 @@ class ThemeController
         }
 
         return $response;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return string
+     */
+    private function extractUrl(Request $request)
+    {
+        $url = $request->headers->get('Referer');
+
+        return !empty($url) ? $url : '/';
     }
 }

--- a/Controller/ThemeController.php
+++ b/Controller/ThemeController.php
@@ -13,8 +13,8 @@ namespace Liip\ThemeBundle\Controller;
 
 use Liip\ThemeBundle\ActiveTheme;
 use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -101,6 +101,6 @@ class ThemeController
     {
         $url = $request->headers->get('Referer');
 
-        return !empty($url) ? $url : '/';
+        return empty($url) ? '/' : $url;
     }
 }

--- a/Controller/ThemeController.php
+++ b/Controller/ThemeController.php
@@ -79,7 +79,7 @@ class ThemeController
             $cookie = new Cookie(
                 $this->cookieOptions['name'],
                 $theme,
-                time() + $this->cookieOptions['lifetime'],
+                $request->server->get('REQUEST_TIME') + $this->cookieOptions['lifetime'],
                 $this->cookieOptions['path'],
                 $this->cookieOptions['domain'],
                 (bool) $this->cookieOptions['secure'],

--- a/Tests/Common/Comparator/SymfonyResponse.php
+++ b/Tests/Common/Comparator/SymfonyResponse.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Liip\ThemeBundle\Tests\Common\Comparator;
+
+use SebastianBergmann\Comparator\Comparator;
+use SebastianBergmann\Comparator\Factory;
+use SebastianBergmann\Comparator\ObjectComparator;
+use Symfony\Component\HttpFoundation\Response;
+
+class SymfonyResponse extends Comparator
+{
+    const PREDEFINED_DATE = 'Tue, 15 Nov 1994 08:12:31 GMT';
+
+    /**
+     * @var ObjectComparator
+     */
+    private $inner;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->inner = new ObjectComparator();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function accepts($expected, $actual)
+    {
+        return
+            $expected instanceof Response
+                &&
+            $actual instanceof Response
+                &&
+            $this->inner->accepts($expected, $actual);
+    }
+
+    /**
+     * @param Response $expected
+     * @param Response $actual
+     * {@inheritdoc}
+     */
+    public function assertEquals($expected, $actual, $delta = 0, $canonicalize = false, $ignoreCase = false)
+    {
+        $expected->headers->set('Date', self::PREDEFINED_DATE);
+        $actual->headers->set('Date', self::PREDEFINED_DATE);
+
+        $this->inner->assertEquals($expected, $actual, $delta, $canonicalize, $ignoreCase);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFactory(Factory $factory)
+    {
+        $this->inner->setFactory($factory);
+    }
+}

--- a/Tests/Controller/ThemeControllerTest.php
+++ b/Tests/Controller/ThemeControllerTest.php
@@ -9,10 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Liip\ThemeBundle\Controller;
+namespace Liip\ThemeBundle\Tests\Controller;
 
 use Liip\ThemeBundle\ActiveTheme;
+use Liip\ThemeBundle\Controller\ThemeController;
+use Liip\ThemeBundle\Tests\Common\Comparator\SymfonyResponse as SymfonyResponseComparator;
 use PHPUnit\Framework\MockObject\Matcher\Invocation;
+use SebastianBergmann\Comparator\Factory as ComparatorFactory;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -22,6 +25,11 @@ class ThemeControllerTest extends \PHPUnit\Framework\TestCase
     const RIGHT_THEME = 'right_theme';
     const REFERER = 'some_referer';
     const DEFAULT_REDIRECT_URL = '/';
+
+    /**
+     * @var SymfonyResponseComparator
+     */
+    private $symfonyResponseComparator;
 
     /**
      * @dataProvider switchActionDataProvider
@@ -79,6 +87,22 @@ class ThemeControllerTest extends \PHPUnit\Framework\TestCase
         $controller = $this->createThemeController(self::never());
 
         $controller->switchAction($this->createRequestWithWrongTheme());
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->symfonyResponseComparator = new SymfonyResponseComparator();
+        ComparatorFactory::getInstance()->register($this->symfonyResponseComparator);
+    }
+
+    protected function tearDown()
+    {
+        ComparatorFactory::getInstance()->unregister($this->symfonyResponseComparator);
+        $this->symfonyResponseComparator = null;
+
+        parent::tearDown();
     }
 
     /**

--- a/Tests/Controller/ThemeControllerTest.php
+++ b/Tests/Controller/ThemeControllerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Liip/ThemeBundle
+ *
+ * (c) Liip AG
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\ThemeBundle\Controller;
+
+use Liip\ThemeBundle\ActiveTheme;
+use PHPUnit\Framework\MockObject\Matcher\Invocation;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class ThemeControllerTest extends \PHPUnit\Framework\TestCase
+{
+    const WRONG_THEME = 'wrong_theme';
+    const RIGHT_THEME = 'right_theme';
+    const REFERER = 'some_referer';
+    const DEFAULT_REDIRECT_URL = '/';
+
+    /**
+     * @dataProvider switchActionDataProvider
+     * @param string|null $referer
+     * @param RedirectResponse $expectedResponse
+     */
+    public function testSwitchAction($referer, RedirectResponse $expectedResponse)
+    {
+        $controller = $this->createThemeController(self::once());
+
+        $actualResponse = $controller->switchAction($this->createRequest($referer));
+
+        self::assertEquals($expectedResponse, $actualResponse);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function switchActionDataProvider()
+    {
+        return array(
+            'not empty referer' => array(
+                'referer' => self::REFERER,
+                'expectedResponse' => $this->createExpectedResponse(self::REFERER),
+            ),
+            'empty string as referer' => array(
+                'referer' => '',
+                'expectedResponse' => $this->createExpectedResponse(self::DEFAULT_REDIRECT_URL),
+            ),
+            'zero string as referer' => array(
+                'referer' => '0',
+                'expectedResponse' => $this->createExpectedResponse(self::DEFAULT_REDIRECT_URL),
+            ),
+            'zero int as referer' => array(
+                'referer' => 0,
+                'expectedResponse' => $this->createExpectedResponse(self::DEFAULT_REDIRECT_URL),
+            ),
+            'empty array as referer' => array(
+                'referer' => array(),
+                'expectedResponse' => $this->createExpectedResponse(self::DEFAULT_REDIRECT_URL),
+            ),
+            'null as referer' => array(
+                'referer' => null,
+                'expectedResponse' => $this->createExpectedResponse(self::DEFAULT_REDIRECT_URL),
+            ),
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedExceptionMessage The theme "wrong_theme" does not exist
+     */
+    public function testSwitchActionWithNotFoundTheme()
+    {
+        $controller = $this->createThemeController(self::never());
+
+        $controller->switchAction($this->createRequestWithWrongTheme());
+    }
+
+    /**
+     * @param Invocation $activeThemeInvocation
+     * @param mixed[]|null $cookieOptions
+     * @return ThemeController
+     */
+    private function createThemeController(Invocation $activeThemeInvocation, array $cookieOptions = null)
+    {
+        return new ThemeController(
+            $this->createActiveThemeMock($activeThemeInvocation),
+            array(self::RIGHT_THEME),
+            $cookieOptions
+        );
+    }
+
+    /**
+     * @param Invocation $invocation
+     * @return ActiveTheme
+     */
+    private function createActiveThemeMock(Invocation $invocation)
+    {
+        $mock = $this->createMock('\Liip\ThemeBundle\ActiveTheme');
+
+        $mock
+            ->expects($invocation)
+            ->method('setName')
+            ->with(self::RIGHT_THEME)
+        ;
+
+        return $mock;
+    }
+
+    /**
+     * @param string|null $referer
+     * @return Request
+     */
+    private function createRequest($referer)
+    {
+        $request = new Request(array('theme' => self::RIGHT_THEME));
+
+        $request->headers->add(
+            array('Referer' => array($referer))
+        );
+
+        return $request;
+    }
+
+    /**
+     * @return Request
+     */
+    private function createRequestWithWrongTheme()
+    {
+        return new Request(array('theme' => self::WRONG_THEME));
+    }
+
+    /**
+     * @param string $url
+     * @return RedirectResponse
+     */
+    private function createExpectedResponse($url)
+    {
+        return new RedirectResponse($url);
+    }
+}

--- a/Tests/UseCaseTest.php
+++ b/Tests/UseCaseTest.php
@@ -12,10 +12,10 @@
 
 namespace Liip\ThemeBundle\Tests\EventListener;
 
-use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Liip\ThemeBundle\EventListener\ThemeRequestListener;
-use Liip\ThemeBundle\Controller\ThemeController;
 use Liip\ThemeBundle\ActiveTheme;
+use Liip\ThemeBundle\Controller\ThemeController;
+use Liip\ThemeBundle\EventListener\ThemeRequestListener;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * Bundle Functional tests.
@@ -98,7 +98,14 @@ class UseCaseTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $request->server->expects($this->any())
             ->method('get')
-            ->will($this->returnValue($userAgent));
+            ->will(
+                $this->returnValueMap(
+                    array(
+                        array('HTTP_USER_AGENT', null, $userAgent),
+                        array('REQUEST_TIME', null, 123),
+                    )
+                )
+            );
 
         return $request;
     }


### PR DESCRIPTION
This exception occurs when 'Referer' header exists but empty.

In this case empty string goes to the first arg of  \Symfony\Component\HttpFoundation\RedirectResponse constructor.

And then \InvalidArgumentException is thrown inside [\Symfony\Component\HttpFoundation\RedirectResponse::setTargetUrl method](https://github.com/symfony/symfony/blob/v4.2.8/src/Symfony/Component/HttpFoundation/RedirectResponse.php#L86).