### PR TITLE
Add abandoned note and upgrade to sylius theme bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "conflict": {
         "sebastian/comparator": "1.2.3"
     },
+    "abandoned": "sylius/theme-bundle",
     "extra": {
         "branch-alias": {
             "dev-master": "1.4-dev"


### PR DESCRIPTION
@lsmith77 did ask me if somebody could write a migration guide to switch from liip theme bundle to the [sylius theme bundle](https://github.com/Sylius/SyliusThemeBundle) to abandoned this project. As discussed in #203 this bundle will be deprecated / abandoned and will recommend the sylius theme bundle. 

I want to thank @liip and all the maintainers and contributors of this bundle 🙏 ! The bundle did a really great job the last year without any problems in lot of projects which where build with @sulu. 